### PR TITLE
Allow symfony console 2.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.1",
         "filp/whoops": "^2.1.4",
-        "symfony/console": "~3.3"
+        "symfony/console": "~2.8|~3.3"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
I haven't tested this, but I'd like to try to get this in Magento2.2, which only supports `~2.3`. But 2.8 usually shouldn't have any big BC breaks with 3