### PR TITLE
Hides details of exception on Artisan CommandNotFoundException

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,1 +1,3 @@
 preset: laravel
+disabled:
+  - self_accessor

--- a/src/Adapters/Laravel/ExceptionHandler.php
+++ b/src/Adapters/Laravel/ExceptionHandler.php
@@ -14,6 +14,7 @@ namespace NunoMaduro\Collision\Adapters\Laravel;
 use Exception;
 use NunoMaduro\Collision\Provider;
 use Illuminate\Contracts\Foundation\Application;
+use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Illuminate\Contracts\Debug\ExceptionHandler as ExceptionHandlerContract;
 use NunoMaduro\Collision\Contracts\Adapters\Phpunit\Listener as ListenerContract;
 
@@ -39,6 +40,15 @@ class ExceptionHandler implements ExceptionHandlerContract
      * @var \Illuminate\Contracts\Foundation\Application
      */
     protected $app;
+
+    /**
+     * A list of the exceptions where the stack trace should't appear.
+     *
+     * @var array
+     */
+    protected $withoutStackTrace = [
+        CommandNotFoundException::class,
+    ];
 
     /**
      * Creates a new instance of the ExceptionHandler.
@@ -83,6 +93,12 @@ class ExceptionHandler implements ExceptionHandlerContract
             ->setOutput($output);
 
         $handler->setInspector((new Inspector($e)));
+
+        if (in_array(get_class($e), $this->withoutStackTrace)) {
+            $handler->getWriter()
+                ->showTrace(false)
+                ->showEditor(false);
+        }
 
         $handler->handle();
     }

--- a/src/Adapters/Laravel/ExceptionHandler.php
+++ b/src/Adapters/Laravel/ExceptionHandler.php
@@ -42,11 +42,11 @@ class ExceptionHandler implements ExceptionHandlerContract
     protected $app;
 
     /**
-     * A list of the exceptions where the stack trace should't appear.
+     * A list of the exceptions where the editor and the trace should't appear.
      *
      * @var array
      */
-    protected $withoutStackTrace = [
+    protected $hideDetails = [
         CommandNotFoundException::class,
     ];
 
@@ -94,7 +94,7 @@ class ExceptionHandler implements ExceptionHandlerContract
 
         $handler->setInspector((new Inspector($e)));
 
-        if (in_array(get_class($e), $this->withoutStackTrace)) {
+        if (in_array(get_class($e), $this->hideDetails)) {
             $handler->getWriter()
                 ->showTrace(false)
                 ->showEditor(false);

--- a/src/Contracts/Handler.php
+++ b/src/Contracts/Handler.php
@@ -29,4 +29,11 @@ interface Handler extends HandlerInterface
      * @return \NunoMaduro\Collision\Contracts\Handler
      */
     public function setOutput(OutputInterface $output): Handler;
+
+    /**
+     * Returns the writer.
+     *
+     * @return \NunoMaduro\Collision\Contracts\Writer
+     */
+    public function getWriter(): Writer;
 }

--- a/src/Contracts/Provider.php
+++ b/src/Contracts/Provider.php
@@ -11,8 +11,6 @@
 
 namespace NunoMaduro\Collision\Contracts;
 
-use Whoops\Handler\HandlerInterface;
-
 /**
  * This is an Collision Provider implementation.
  *
@@ -30,7 +28,7 @@ interface Provider
     /**
      * Returns the handler.
      *
-     * @return \Whoops\Handler\HandlerInterface
+     * @return \NunoMaduro\Collision\Contracts\Handler
      */
-    public function getHandler(): HandlerInterface;
+    public function getHandler(): Handler;
 }

--- a/src/Contracts/Writer.php
+++ b/src/Contracts/Writer.php
@@ -41,6 +41,15 @@ interface Writer
     public function showTrace(bool $show): Writer;
 
     /**
+     * Declares whether or not the Writer should show the editor.
+     *
+     * @param  bool $show
+     *
+     * @return \NunoMaduro\Collision\Contracts\Writer
+     */
+    public function showEditor(bool $show): Writer;
+
+    /**
      * Writes the details of the exception on the console.
      *
      * @param \Whoops\Exception\Inspector $inspector

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -59,4 +59,12 @@ class Handler extends AbstractHandler implements HandlerContract
 
         return $this;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getWriter(): WriterContract
+    {
+        return $this->writer;
+    }
 }

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -13,7 +13,7 @@ namespace NunoMaduro\Collision;
 
 use Whoops\Run;
 use Whoops\RunInterface;
-use Whoops\Handler\HandlerInterface;
+use NunoMaduro\Collision\Contracts\Handler as HandlerContract;
 use NunoMaduro\Collision\Contracts\Provider as ProviderContract;
 
 /**
@@ -41,9 +41,9 @@ class Provider implements ProviderContract
      * Creates a new instance of the Provider.
      *
      * @param \Whoops\RunInterface|null $run
-     * @param \Whoops\Handler\HandlerInterface|null $handler
+     * @param \NunoMaduro\Collision\Contracts\Handler|null $handler
      */
-    public function __construct(RunInterface $run = null, HandlerInterface $handler = null)
+    public function __construct(RunInterface $run = null, HandlerContract $handler = null)
     {
         $this->run = $run ?: new Run;
         $this->handler = $handler ?: new Handler;
@@ -63,7 +63,7 @@ class Provider implements ProviderContract
     /**
      * {@inheritdoc}
      */
-    public function getHandler(): HandlerInterface
+    public function getHandler(): HandlerContract
     {
         return $this->handler;
     }

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -60,6 +60,13 @@ class Writer implements WriterContract
     protected $showTrace = true;
 
     /**
+     * Declares whether or not the editor should appear.
+     *
+     * @var bool
+     */
+    protected $showEditor = true;
+
+    /**
      * Creates an instance of the writer.
      *
      * @param \Symfony\Component\Console\Output\OutputInterface|null $output
@@ -79,7 +86,12 @@ class Writer implements WriterContract
         $this->renderTitle($inspector);
 
         $frames = $this->getFrames($inspector);
-        $this->renderEditor(array_shift($frames));
+
+        $editorFrame = array_shift($frames);
+
+        if ($this->showEditor) {
+            $this->renderEditor($editorFrame);
+        }
 
         if ($this->showTrace && ! empty($frames)) {
             $this->renderTrace($frames);
@@ -104,6 +116,16 @@ class Writer implements WriterContract
     public function showTrace(bool $show): WriterContract
     {
         $this->showTrace = $show;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function showEditor(bool $show): WriterContract
+    {
+        $this->showEditor = $show;
 
         return $this;
     }


### PR DESCRIPTION
Concerning the Laravel adapter, when running the artisan CLI, the user may use a command name that don't exist. This PR addresses the hide of the detail of that specific exception `Symfony\Component\Console\Exception\CommandNotFoundException`.

## Before:

<img width="1129" alt="screenshot 2017-11-15 01 21 10" src="https://user-images.githubusercontent.com/5457236/32812052-50830bd4-c9a3-11e7-8ddc-e58fac300c78.png">


## After:

<img width="945" alt="screenshot 2017-11-15 01 20 34" src="https://user-images.githubusercontent.com/5457236/32812055-51e9596a-c9a3-11e7-940b-f6d2131cdaf9.png">
