### PR TITLE
Specifying the phpunit version in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ If you are not using Laravel, you need to register the handler in your code:
 
 Add the following configuration to your `phpunit.xml`
 
+Phpunit must be 6.0 or higher.
+
 ```xml
     <listeners>
         <listener class="NunoMaduro\Collision\Adapters\Phpunit\Listener" />


### PR DESCRIPTION
Now i have an error when use collision as phpunit listener.

~~~php
Fatal error: Declaration of NunoMaduro\Collision\Adapters\Phpunit\Listener::addError(PHPUnit\Framework\Test $test, Exception $e, $time) must be compatible with PHPUnit_Framework_TestListener::addError(PHPUnit_Framework_Test $test, Exception $e, $time) in /Users/dmitriy/projects/ph/vendor/nunomaduro/collision/src/Adapters/Phpunit/Listener.php on line 33
~~~

And it will work after phpunit 6.0