### PR TITLE
add support to phpunit 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you are not using Laravel, you need to register the handler in your code:
 
 ## Phpunit adapter
 
-Phpunit must be 6.0 or higher.
+Phpunit must be 7.0 or higher.
 
 Add the following configuration to your `phpunit.xml`:
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/console": "~2.8|~3.3|~4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.5",
+        "phpunit/phpunit": "~7",
         "laravel/framework": "5.5.*"
     },
     "autoload-dev": {

--- a/src/Adapters/Phpunit/Listener.php
+++ b/src/Adapters/Phpunit/Listener.php
@@ -11,7 +11,6 @@
 
 namespace NunoMaduro\Collision\Adapters\Phpunit;
 
-use Exception;
 use ReflectionObject;
 use PHPUnit\Framework\Test;
 use PHPUnit\Framework\Warning;
@@ -59,9 +58,9 @@ class Listener implements ListenerContract
     /**
      * {@inheritdoc}
      */
-    public function render(\Throwable $e)
+    public function render(\Throwable $t)
     {
-        $inspector = new Inspector($e);
+        $inspector = new Inspector($t);
 
         $this->writer->write($inspector);
     }
@@ -69,79 +68,79 @@ class Listener implements ListenerContract
     /**
      * {@inheritdoc}
      */
-    public function addError(Test $test, Exception $e, $time)
+    public function addError(Test $test, \Throwable $t, float $time): void
     {
         if ($this->exceptionFound === null) {
-            $this->exceptionFound = $e;
+            $this->exceptionFound = $t;
         }
     }
 
     /**
      * {@inheritdoc}
      */
-    public function addWarning(Test $test, Warning $e, $time)
+    public function addWarning(Test $test, Warning $t, float $time): void
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function addFailure(Test $test, AssertionFailedError $e, $time)
+    public function addFailure(Test $test, AssertionFailedError $t, float $time): void
     {
         $this->writer->ignoreFilesIn(['/vendor/'])
             ->showTrace(false);
 
         if ($this->exceptionFound === null) {
-            $this->exceptionFound = $e;
+            $this->exceptionFound = $t;
         }
     }
 
     /**
      * {@inheritdoc}
      */
-    public function addIncompleteTest(Test $test, Exception $e, $time)
+    public function addIncompleteTest(Test $test, \Throwable $t, float $time): void
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function addRiskyTest(Test $test, Exception $e, $time)
+    public function addRiskyTest(Test $test, \Throwable $t, float $time): void
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function addSkippedTest(Test $test, Exception $e, $time)
+    public function addSkippedTest(Test $test, \Throwable $t, float $time): void
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function startTestSuite(TestSuite $suite)
+    public function startTestSuite(TestSuite $suite): void
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function endTestSuite(TestSuite $suite)
+    public function endTestSuite(TestSuite $suite): void
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function startTest(Test $test)
+    public function startTest(Test $test): void
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function endTest(Test $test, $time)
+    public function endTest(Test $test, float $time): void
     {
     }
 

--- a/src/Contracts/Adapters/Phpunit/Listener.php
+++ b/src/Contracts/Adapters/Phpunit/Listener.php
@@ -24,9 +24,9 @@ interface Listener extends TestListener
      * Renders the provided error
      * on the console.
      *
-     * @param  \Throwable $e
+     * @param  \Throwable $t
      *
      * @return void
      */
-    public function render(\Throwable $e);
+    public function render(\Throwable $t);
 }

--- a/tests/Unit/Adapters/PhpunitTest.php
+++ b/tests/Unit/Adapters/PhpunitTest.php
@@ -96,11 +96,11 @@ class PhpunitTest extends TestCase
 
 class FakeTest implements Test
 {
-    public function run(TestResult $result = null)
+    public function run(TestResult $result = null): TestResult
     {
     }
 
-    public function count()
+    public function count(): int
     {
         return 0;
     }


### PR DESCRIPTION
This PR allows Collision supports PHPUnit 7+. For this reason, it also needs a major version update since it doesn't support PHPUnit 6 anymore.