### PR TITLE
Removes spaces between file and line number

### DIFF
--- a/src/Writer.php
+++ b/src/Writer.php
@@ -212,7 +212,7 @@ class Writer implements WriterContract
      */
     protected function renderEditor(Frame $frame): WriterContract
     {
-        $this->render('at <fg=green>'.$frame->getFile().'</>'.': <fg=green>'.$frame->getLine().'</>');
+        $this->render('at <fg=green>'.$frame->getFile().'</>'.':<fg=green>'.$frame->getLine().'</>');
 
         $content = $this->highlighter->highlight($frame->getFileContents(), (int) $frame->getLine());
 
@@ -246,7 +246,7 @@ class Writer implements WriterContract
             $pos = str_pad($i + 1, 4, ' ');
 
             $this->render("<comment><fg=cyan>$pos</>$class$function($args)</comment>");
-            $this->render("    <fg=green>$file</> : <fg=green>$line</>", false);
+            $this->render("    <fg=green>$file</>:<fg=green>$line</>", false);
         }
 
         return $this;

--- a/tests/Unit/WriterTest.php
+++ b/tests/Unit/WriterTest.php
@@ -50,7 +50,7 @@ class WriterTest extends TestCase
 
    Tests\FakeProgram\FakeException  : Fail description
 
-  at $projectDir/FakeProgram/HelloWorldFile3.php: 9
+  at $projectDir/FakeProgram/HelloWorldFile3.php:9
      5| class HelloWorldFile3
      6| {
      7|     public static function say()
@@ -63,10 +63,10 @@ class WriterTest extends TestCase
   Exception trace:
 
   1   Tests\FakeProgram\HelloWorldFile3::say()
-      $projectDir/FakeProgram/HelloWorldFile2.php : 9
+      $projectDir/FakeProgram/HelloWorldFile2.php:9
 
   2   Tests\FakeProgram\HelloWorldFile2::say()
-      $projectDir/FakeProgram/HelloWorldFile1.php : 9
+      $projectDir/FakeProgram/HelloWorldFile1.php:9
 
   Please use the argument -v to see more details.
 
@@ -95,7 +95,7 @@ EOF;
 
    Tests\FakeProgram\FakeException  : Fail description
 
-  at $projectDir/FakeProgram/HelloWorldFile3.php: 9
+  at $projectDir/FakeProgram/HelloWorldFile3.php:9
      5| class HelloWorldFile3
      6| {
      7|     public static function say()
@@ -108,13 +108,13 @@ EOF;
   Exception trace:
 
   1   Tests\FakeProgram\HelloWorldFile3::say()
-      $projectDir/FakeProgram/HelloWorldFile2.php : 9
+      $projectDir/FakeProgram/HelloWorldFile2.php:9
 
   2   Tests\FakeProgram\HelloWorldFile2::say()
-      $projectDir/FakeProgram/HelloWorldFile1.php : 9
+      $projectDir/FakeProgram/HelloWorldFile1.php:9
 
   3   Tests\FakeProgram\HelloWorldFile1::say()
-      $projectDir/Unit/WriterTest.php :
+      $projectDir/Unit/WriterTest.php:
 EOF;
 
         $this->assertContains($result, $writer->getOutput()->fetch());
@@ -161,10 +161,10 @@ EOF;
   Exception trace:
 
   1   Tests\FakeProgram\HelloWorldFile3::say()
-      $projectDir/FakeProgram/HelloWorldFile2.php : 9
+      $projectDir/FakeProgram/HelloWorldFile2.php:9
 
   2   Tests\FakeProgram\HelloWorldFile2::say()
-      $projectDir/FakeProgram/HelloWorldFile1.php : 9
+      $projectDir/FakeProgram/HelloWorldFile1.php:9
 
   Please use the argument -v to see more details.
 
@@ -191,7 +191,7 @@ EOF;
 
    Tests\FakeProgram\FakeException  : Fail description
 
-  at $projectDir/FakeProgram/HelloWorldFile3.php: 9
+  at $projectDir/FakeProgram/HelloWorldFile3.php:9
      5| class HelloWorldFile3
      6| {
      7|     public static function say()


### PR DESCRIPTION
This is a small fix that changes the two places I know of that prints file + linenumber.

From

```
at /path/File.php: 767
/path/File.php : 767
```

to

```
at /path/File.php:767
/path/File.php:767
```

I find this to be more consistent, easier to read and most importantly it makes it possible to open the file in an editor and have it scroll to the specific line.

E.g in iTerm2 you can Cmd+click the link and have it opened at the correct line in Sublime Text.
