### PR TITLE
Defer service provider

### DIFF
--- a/src/Adapters/Laravel/CollisionServiceProvider.php
+++ b/src/Adapters/Laravel/CollisionServiceProvider.php
@@ -28,6 +28,13 @@ use NunoMaduro\Collision\Contracts\Adapters\Phpunit\Listener as ListenerContract
 class CollisionServiceProvider extends ServiceProvider
 {
     /**
+     * Indicates if loading of the provider is deferred.
+     *
+     * @var bool
+     */
+    protected $defer = true;
+
+    /**
      * {@inheritdoc}
      */
     public function register()


### PR DESCRIPTION
Since you are only wanting this provider to do stuff when you are on the console, it can be deferred. All providers are loaded in the console environment regardless of whether they are deferred or not. This will prevent CollisionServiceProvider from ever being loaded at all in the HTTP environment.