### PR TITLE
Fix ExceptionHandler for use with swoole

### DIFF
--- a/src/Adapters/Laravel/ExceptionHandler.php
+++ b/src/Adapters/Laravel/ExceptionHandler.php
@@ -52,7 +52,7 @@ class ExceptionHandler implements ExceptionHandlerContract
     }
 
     /**
-     * Converts \Throwable to \Exception
+     * Converts \Throwable to \Exception.
      *
      * @param  \Throwable|\Exception $e
      *
@@ -62,7 +62,6 @@ class ExceptionHandler implements ExceptionHandlerContract
     {
         return ($e instanceof \Throwable) ? new \Exception($e->getMessage(), $e->getCode(), $e) : $e;
     }
-
 
     /**
      * {@inheritdoc}

--- a/src/Adapters/Laravel/ExceptionHandler.php
+++ b/src/Adapters/Laravel/ExceptionHandler.php
@@ -88,8 +88,6 @@ class ExceptionHandler implements ExceptionHandlerContract
      */
     public function renderForConsole($output, $e)
     {
-        $e = $this->convertThrowable($e);
-
         if ($e instanceof SymfonyConsoleExceptionInterface) {
             $this->appExceptionHandler->renderForConsole($output, $e);
         } else {
@@ -112,8 +110,6 @@ class ExceptionHandler implements ExceptionHandlerContract
      */
     public function shouldReport($e)
     {
-        return $this->appExceptionHandler->shouldReport(
-            $this->convertThrowable($e)
-        );
+        return $this->appExceptionHandler->shouldReport($e);
     }
 }


### PR DESCRIPTION
Fix ExceptionHandler for use with swoole. Sometimes Exception must be Throwable, and we convert it.