### PR TITLE
Support PHPUnit version 8 identifier requirement

### DIFF
--- a/src/Adapters/Phpunit/Listener.php
+++ b/src/Adapters/Phpunit/Listener.php
@@ -24,7 +24,7 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 use NunoMaduro\Collision\Contracts\Writer as WriterContract;
 use NunoMaduro\Collision\Contracts\Adapters\Phpunit\Listener as ListenerContract;
 
-if (class_exists(\PHPUnit\Runner\Version::class) && substr(\PHPUnit\Runner\Version::id(), 0, 2) === '7.') {
+if (class_exists(\PHPUnit\Runner\Version::class) && intval(substr(\PHPUnit\Runner\Version::id(), 0, 1)) >= 7) {
 
     /**
      * This is an Collision Phpunit Adapter implementation.


### PR DESCRIPTION
This PR modifies the PHPUnit version requirement in 'NunoMaduro\Collision\Adapters\Phpunit\Listener' to instead ensure that version 7 is the required minimum, while future versions will be automatically accepted.

This fixes #59 

I couldn't immediately determine an easy way to add a test for this functionality for a number of reasons:

1. There was no version 7 test to begin with.
2. PHPUnit 8 requires updates to other dependencies.
3. I'm not entirely sure how you would mock a PHPUnit class itself.

