### PR TITLE
Add shouldReport to ExceptionHandler

### DIFF
--- a/src/Adapters/Laravel/ExceptionHandler.php
+++ b/src/Adapters/Laravel/ExceptionHandler.php
@@ -59,6 +59,14 @@ class ExceptionHandler implements ExceptionHandlerContract
     {
         $this->appExceptionHandler->report($e);
     }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function shouldReport(Exception $e)
+    {
+        $this->appExceptionHandler->shouldReport($e);
+    }
 
     /**
      * {@inheritdoc}

--- a/src/Adapters/Laravel/ExceptionHandler.php
+++ b/src/Adapters/Laravel/ExceptionHandler.php
@@ -59,7 +59,7 @@ class ExceptionHandler implements ExceptionHandlerContract
     {
         $this->appExceptionHandler->report($e);
     }
-    
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
`shouldReport()` was added to the `ExceptionHandler` interface in Laravel 5.8. When it is not present in this class, it throws an error.

See this PR on Laravel Framework:
laravel/framework#26193