### PR TITLE
Alias the stable branch to 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
             ]
         },
         "branch-alias": {
-            "dev-next": "4.x-dev"
+            "dev-stable": "3.x-dev"
         }
     },
     "scripts": {


### PR DESCRIPTION
So, hopefully, we only need the alias for 4.x on the branch it's actually aliasing, so we can remove that. We should also tell Packagist that the stable branch corresponds to 3.x.