### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 Collision was created by, and is maintained by [Nuno Maduro](https://github.com/nunomaduro), and is an error handler framework for console/command-line PHP applications.
 
-- Build on top of [Whoops](https://github.com/filp/whoops).
+- Built on top of [Whoops](https://github.com/filp/whoops).
 - Supports [Laravel](https://github.com/laravel/laravel) Artisan & [PHPUnit](https://github.com/sebastianbergmann/phpunit).
 - Built with [PHP 7](https://php.net) using modern coding standards.
 


### PR DESCRIPTION
I found a minor typo in the readme. I think it should be "built" with a "t".