### PR TITLE
Fix all psalm errors

### DIFF
--- a/src/Adapters/Laravel/ExceptionHandler.php
+++ b/src/Adapters/Laravel/ExceptionHandler.php
@@ -90,7 +90,7 @@ class ExceptionHandler implements ExceptionHandlerContract
     /**
      * Determine if the exception should be reported.
      *
-     * @param  \Exception  $e
+     * @param  Throwable $e
      * @return bool
      */
     public function shouldReport(Throwable $e)

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -270,7 +270,8 @@ class Writer implements WriterContract
     {
         $file = $this->getFileRelativePath((string) $frame->getFile());
 
-        $this->render('at <fg=green>'.$file.'</>'.':<fg=green>'.$frame->getLine().'</>');
+        $line = $frame->getLine() ?? '0';
+        $this->render('at <fg=green>'.$file.'</>'.':<fg=green>'.$line.'</>');
 
         $content = $this->highlighter->highlight((string) $frame->getFileContents(), (int) $frame->getLine());
 
@@ -307,7 +308,7 @@ class Writer implements WriterContract
             $class = empty($frame->getClass()) ? '' : $frame->getClass().'::';
             $function = $frame->getFunction();
             $args = $this->argumentFormatter->format($frame->getArgs());
-            $pos = str_pad((int) $i + 1, 4, ' ');
+            $pos = str_pad((string) ((int) $i + 1), 4, ' ');
 
             if ($vendorFrames > 0) {
                 $this->output->write(

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -270,7 +270,8 @@ class Writer implements WriterContract
     {
         $file = $this->getFileRelativePath((string) $frame->getFile());
 
-        $line = $frame->getLine() ?? '0';
+        // getLine() might return null so cast to int to get 0 instead
+        $line = (int) $frame->getLine();
         $this->render('at <fg=green>'.$file.'</>'.':<fg=green>'.$line.'</>');
 
         $content = $this->highlighter->highlight((string) $frame->getFileContents(), (int) $frame->getLine());


### PR DESCRIPTION
Hello,

It's nice to find some projects that already use static analysis tools like phpstan. With `psalm` I was ablet to find other errors, that I'm fixing with this PR:

* align the shouldReport() docblock with correct param type
* the getLine() from Whoops can return null, so display 0 if it is the
  case
* the str_pad() first argument should be a string

This set of changes brings down the number of errors reported by psalm
from 3 to 0 \o/

![2020-01-22-234937_629x193_scrot](https://user-images.githubusercontent.com/3043706/72941679-de654900-3d71-11ea-8127-8e6d47e3b653.png)
