### PR TITLE
Fix loading APP_ENV specific .env files

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,3 +12,8 @@ parameters:
         - '#Parameter \#1 \$input of function str_pad expects string, int given.#'
         - '#Cannot call method addTheme\(\) on array|JakubOnderka\\PhpConsoleColor\\ConsoleColor#'
         - '#Method NunoMaduro\\Collision\\Adapters\\Laravel\\IgnitionSolutionsRepository::getFromThrowable\(\) should return array<int,#'
+        - '#Result of static method Dotenv\\Repository\\RepositoryBuilder::create\(\) \(void\) is used.#'
+        - message: '#Cannot call method make\(\) on void.#'
+          paths:
+                - src/Adapters/Laravel/Commands/*
+


### PR DESCRIPTION
When running `php artisan test` environment specific .env files aren't loaded.

Creating a fresh Laravel installation comes with a phpunit.xml file where `APP_ENV=testing` is defined. When running `phpunit` it would load a .env.testing file if it exists in the project root and include those variables when testing.

This should fix and mimic the same way as Laravel loads environment specific .env files when running `php artisan test`
