### PR TITLE
Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^7.2.5",
         "facade/ignition-contracts": "^1.0",
         "filp/whoops": "^2.4",
-        "jakub-onderka/php-console-highlighter": "^0.4",
+        "php-parallel-lint/php-parallel-lint": "^0.4",
         "symfony/console": "^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
Package jakub-onderka/php-console-highlighter is abandoned is throw a warning now when installing.
```
Package jakub-onderka/php-console-color is abandoned, you should avoid using it. Use php-parallel-lint/php-console-color instead.
Package jakub-onderka/php-console-highlighter is abandoned, you should avoid using it. Use php-parallel-lint/php-console-highlighter instead.
```
it have been replaced with php-parallel-lint/php-parallel-lint as mentioned from the author 

