### PR TITLE
feat(better-ci-support): removes usage of ANSI escape sequences

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,4 @@ before_script:
 
 script:
     - composer test
+    - ./vendor/bin/phpunit

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,6 +14,7 @@
          stopOnError="false"
          stopOnFailure="false"
          verbose="true"
+         printerClass="NunoMaduro\Collision\Adapters\Phpunit\Printer"
 >
     <testsuites>
         <testsuite name="Collision Test Suite">

--- a/src/Adapters/Phpunit/PrinterContents.php
+++ b/src/Adapters/Phpunit/PrinterContents.php
@@ -166,7 +166,6 @@ trait PrinterContents
 
             $this->style->writeCurrentRecap($this->state);
 
-            // $this->style->updateFooter($this->state);
             $this->style->writeRecap($this->state, $this->timer);
         }
     }
@@ -184,8 +183,6 @@ trait PrinterContents
 
             $this->state->moveTo($testCase);
         }
-
-        // $this->style->updateFooter($this->state, $testCase);
     }
 
     /**

--- a/src/Adapters/Phpunit/PrinterContents.php
+++ b/src/Adapters/Phpunit/PrinterContents.php
@@ -166,8 +166,8 @@ trait PrinterContents
 
             $this->style->writeCurrentRecap($this->state);
 
-            $this->style->updateFooter($this->state);
-            $this->style->writeRecap($this->timer);
+            // $this->style->updateFooter($this->state);
+            $this->style->writeRecap($this->state, $this->timer);
         }
     }
 
@@ -185,7 +185,7 @@ trait PrinterContents
             $this->state->moveTo($testCase);
         }
 
-        $this->style->updateFooter($this->state, $testCase);
+        // $this->style->updateFooter($this->state, $testCase);
     }
 
     /**

--- a/tests/Unit/Adapters/PhpunitTest.php
+++ b/tests/Unit/Adapters/PhpunitTest.php
@@ -97,7 +97,7 @@ EOF,
         ]);
 
         self::assertStringContainsString(
-            'Tests:  1 warnings, 1 risked, 1 incompleted, 1 skipped, 2 passed',
+            'Tests:  1 warnings, 1 risked, 1 incompleted, 1 skipped, 3 passed',
             $output
         );
     }


### PR DESCRIPTION
This pull request addresses 2 problems in the PHPUnit printer class:

1. Prevents `dumps` & `echos` from getting swallowed by ANSI escape sequences. Fixes https://github.com/nunomaduro/collision/issues/104.
2. Makes the printer class better work with CIs: https://travis-ci.org/github/nunomaduro/collision/jobs/671735955#L504.