### PR TITLE
Add warning message on incomplete tests too

### DIFF
--- a/src/Adapters/Phpunit/PrinterContents.php
+++ b/src/Adapters/Phpunit/PrinterContents.php
@@ -123,7 +123,7 @@ trait PrinterContents
     {
         $testCase = $this->testCaseFromTest($testCase);
 
-        $this->state->add(TestResult::fromTestCase($testCase, TestResult::INCOMPLETE));
+        $this->state->add(TestResult::fromTestCase($testCase, TestResult::INCOMPLETE, $t->getMessage()));
     }
 
     /**


### PR DESCRIPTION
Hi @nunomaduro,
The warning message was not passed for incomplete tests, like it is for risky and skipped ones.

This is done.