### PR TITLE
Avoid reformatting data set name in TestResult output

### DIFF
--- a/src/Adapters/Phpunit/TestResult.php
+++ b/src/Adapters/Phpunit/TestResult.php
@@ -94,7 +94,7 @@ final class TestResult
      */
     public static function makeDescription(TestCase $testCase): string
     {
-        $name = $testCase->getName(true);
+        $name = $testCase->getName(false);
 
         // First, lets replace underscore by spaces.
         $name = str_replace('_', ' ', $name);
@@ -108,8 +108,19 @@ final class TestResult
         // Removes spaces
         $name = (string) trim($name);
 
-        // Finally, lower case everything
-        return (string) mb_strtolower($name);
+        // Lower case everything
+        $name = (string) mb_strtolower($name);
+
+        // Add the dataset name if it has one
+        if ($dataName = $testCase->dataName()) {
+            if (is_int($dataName)) {
+                $name .= sprintf(' with data set #%d', $dataName);
+            } else {
+                $name .= sprintf(' with data set "%s"', $dataName);
+            }
+        }
+
+        return $name;
     }
 
     /**


### PR DESCRIPTION
The formatting that occurs in `TestResult::makeDescription()` applies to the test name to turn snake_case or camelCase test names into more readable strings with whitespace.

This is nice; however, it also applies the formatting to the data set name. Because it is just an array key, the data set name may not be in the predictable format of snake or camel case like a test method.

This reformatting obscures the actual data set name, adds double spaces, and removes underscores where they may be important. It also causes different data sets with names differing only in case or underscores to be identical, therefore collapsing them into a single row in the output.

I have modified the `makeDescription()` method to apply formatting only to the base test name, and then append the unmodified data set name (or index).

**Before:**
```
 ✓ it calculates the points for a letter with data set " " // underscore removed, collapsed with space data set
 ✓ it calculates the points for a letter with data set " a" // upper case removed, unnecessary space added
 ...
 ✓ it calculates the points for a card with data set " queen of  hearts" // double space
 ✓ it implements the interface with data set " app\ contracts\ playing card" // class name broken
```

**After:**
```
 ✓ it calculates the points for a letter with data set " " // space is a different data set
 ✓ it calculates the points for a letter with data set "_" // underscore is a different dataset
 ✓ it calculates the points for a letter with data set "A"
 ...
 ✓ it calculates the points for a card with data set "Queen of Hearts"
 ✓ it implements the interface with data set "App\Contracts\PlayingCard"
```

Hope this is useful!