### PR TITLE
Allow customizing theme styles

### DIFF
--- a/src/Highlighter.php
+++ b/src/Highlighter.php
@@ -91,7 +91,9 @@ final class Highlighter implements HighlighterContract
         }
 
         foreach (self::THEME as $name => $styles) {
-            $this->color->addTheme($name, $styles);
+            if (!$this->color->hasTheme($name)) {
+                $this->color->addTheme($name, $styles);
+            }
         }
         if (!$UTF8) {
             $this->delimiter = self::DELIMITER;


### PR DESCRIPTION
This PR adds support for using custom styles in Collision's output.

Although Collision is capable of supporting 'themes' for different sets of colors and styles, it's currently impossible to actually use this feature without completely overriding both the `ConsoleColor` and `Highlighter` implementations, because Collision internally just sets all the styles back to use its own theme:

https://github.com/nunomaduro/collision/blob/fef86518b5bab6373eb282068bfa4ce25bb723d1/src/Highlighter.php#L87-L95

This PR adds another simple `hasTheme` check, exactly as the above example already does with the default theme on lines 88-90, to ensure Collision doesn't override any previously defined styles.