### PR TITLE
Update TestResult.php

### DIFF
--- a/src/Adapters/Phpunit/TestResult.php
+++ b/src/Adapters/Phpunit/TestResult.php
@@ -153,7 +153,7 @@ final class TestResult
     {
         switch ($type) {
             case self::FAIL:
-                return '•';
+                return '⨯';
             case self::SKIPPED:
                 return 's';
             case self::RISKY:


### PR DESCRIPTION
Replaced the dot unicode symbol for FAIL by the cross symbol:

![image](https://user-images.githubusercontent.com/19224681/83971090-a6ead980-a8d9-11ea-9fc4-bd4df6ee0a12.png)
