### PR TITLE
Switch every test case icons to semantic symbols

### DIFF
--- a/src/Adapters/Phpunit/TestResult.php
+++ b/src/Adapters/Phpunit/TestResult.php
@@ -155,13 +155,13 @@ final class TestResult
             case self::FAIL:
                 return '⨯';
             case self::SKIPPED:
-                return 's';
+                return '-';
             case self::RISKY:
-                return 'r';
+                return '!';
             case self::INCOMPLETE:
-                return 'i';
+                return '…';
             case self::WARN:
-                return 'w';
+                return '!';
             case self::RUNS:
                 return '•';
             default:


### PR DESCRIPTION
Every status icon is now using a semantic symbol to allow for quick scanning and visual cohesion:

- RISKY & WARN both use `!` (reasoning: PHPUnit provides an explanation of the error to understand what's going on.)
- INCOMPLETE uses `…` (reasoning: an ellipsis indicates an intentional omission of something. Here, a test.)
- SKIPPED uses `-` (reasoning : run the suite, "minus" this test)