### PR TITLE
Emit output with beStrictAboutOutputDuringTests=false in Phpunit/Printer

### DIFF
--- a/src/Adapters/Phpunit/Printer.php
+++ b/src/Adapters/Phpunit/Printer.php
@@ -191,6 +191,13 @@ final class Printer implements \PHPUnit\TextUI\ResultPrinter
         if (!$this->state->existsInTestCase($testCase)) {
             $this->state->add(TestResult::fromTestCase($testCase, TestResult::PASS));
         }
+
+        if ($testCase instanceof TestCase
+            && $testCase->getTestResultObject() instanceof \PHPUnit\Framework\TestResult
+            && !$testCase->getTestResultObject()->isStrictAboutOutputDuringTests()
+            && !$testCase->hasExpectationOnOutput()) {
+            $this->style->write($testCase->getActualOutput());
+        }
     }
 
     /**

--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -37,6 +37,14 @@ final class Style
     }
 
     /**
+     * Prints the content.
+     */
+    public function write(string $content): void
+    {
+        $this->output->write($content);
+    }
+
+    /**
      * Prints the content similar too:.
      *
      * ```

--- a/tests/TestCaseWithStdoutOutput/OutputTest.php
+++ b/tests/TestCaseWithStdoutOutput/OutputTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestCaseWithStdoutOutput;
+
+use PHPUnit\Framework\TestCase;
+
+class OutputTest extends TestCase
+{
+    public function testWithOutput()
+    {
+        var_dump('Foo');
+
+        $this->assertTrue(true);
+    }
+
+    public function testNothingSpecial()
+    {
+        // This shouldn't have any output
+        $this->assertTrue(true);
+    }
+
+    public function testWithNoOutput()
+    {
+        $this->expectOutputRegex('/Bar/');
+
+        var_dump('Bar');
+    }
+}

--- a/tests/TestCaseWithStdoutOutput/phpunit.xml
+++ b/tests/TestCaseWithStdoutOutput/phpunit.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit beStrictAboutOutputDuringTests="false">
+</phpunit>


### PR DESCRIPTION
Coming from pest https://github.com/pestphp/pest/issues/73

While PHPUnit's DefaultResultPrinter emits output to stdout anyways if beStrictAboutOutputDuringTests sets false, collision might want to follow the same behavior.