### PR TITLE
Allow installing on Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,10 @@
         "friendsofphp/php-cs-fixer": "^2.16.3",
         "fideloper/proxy": "^4.3",
         "fruitcake/laravel-cors": "^2.0.1",
-        "laravel/framework": "^8.0",
+        "laravel/framework": "^7.18 || ^8.0",
         "laravel/tinker": "^2.4",
         "nunomaduro/larastan": "^0.6.1",
-        "orchestra/testbench": "^6.0",
+        "orchestra/testbench": "^5.0 || ^6.0",
         "phpstan/phpstan": "^0.12.30",
         "phpunit/phpunit": "^9.2.4"
     },

--- a/src/Adapters/Laravel/Commands/TestCommand.php
+++ b/src/Adapters/Laravel/Commands/TestCommand.php
@@ -171,7 +171,8 @@ class TestCommand extends Command
             self::getVersionFourEnvironmentVariables($path, $file);
     }
 
-    private static function getVersionFiveEnvironmentVariables($path, $file)
+    /** @return array<int, string|null> */
+    private static function getVersionFiveEnvironmentVariables(string $path, string $file): array
     {
         try {
             $content = StoreBuilder::createWithNoNames()
@@ -192,9 +193,11 @@ class TestCommand extends Command
         return $vars;
     }
 
-    private static function getVersionFourEnvironmentVariables($path, $file)
+    /** @return array<string, string|null> */
+    private static function getVersionFourEnvironmentVariables(string $path, string $file): array
     {
         return Dotenv::create(
+            // @phpstan-ignore-next-line
             RepositoryBuilder::create()->make(),
             $path,
             $file


### PR DESCRIPTION
Currently Collision 5 isn't compatible with Laravel 7 due to differences between DotEnv 4 and 5. This PR tries to resolve this issue by splitting the versions into multiple methods.