### PR TITLE
Fix frame filtering with windows paths

### DIFF
--- a/src/Writer.php
+++ b/src/Writer.php
@@ -202,7 +202,9 @@ final class Writer implements WriterContract
                     }
 
                     foreach ($this->ignore as $ignore) {
-                        if (preg_match($ignore, $frame->getFile())) {
+                        // Ensure paths are linux-style (like the ones on $this->ignore)
+                        $sanitized_path = str_replace('\\', '/', $frame->getFile());
+                        if (preg_match($ignore, $sanitized_path)) {
                             return false;
                         }
                     }


### PR DESCRIPTION
$this->ignore patterns have linux directory separators (/) so when running on windows (\), these are never filtered.

A better solution would be modifying `/src/Adapters/Phpunit/Style.php:163` so the strings are matched against windows or linux paths, but I don't have the required regex knowledge:

```php
        $writer->ignoreFilesIn([
            '/vendor\/pestphp\/pest/',
            '/vendor\/phpunit\/phpunit\/src/',
            '/vendor\/mockery\/mockery/',
            '/vendor\/laravel\/dusk/',
            '/vendor\/laravel\/framework\/src\/Illuminate\/Testing/',
            '/vendor\/laravel\/framework\/src\/Illuminate\/Foundation\/Testing/',
        ]);
```
Related: https://github.com/pestphp/pest/issues/136#issuecomment-661922988