### PR TITLE
Allow collision to install on PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ^8.0",
         "facade/ignition-contracts": "^1.0",
         "filp/whoops": "^2.7.2",
         "symfony/console": "^5.0"


### PR DESCRIPTION
This is a fix for #151, and simply enables PHP 8.0 in the `composer.json` file.

I had a go at changing the github action to *not* ignore the PHP 8.0 platform mismatch, but other package dependencies cause it to fail, so I left it as is, and it builds fine on all platforms.