### PR TITLE
Add message when no tests are executed

### DIFF
--- a/src/Adapters/Phpunit/Printer.php
+++ b/src/Adapters/Phpunit/Printer.php
@@ -230,7 +230,7 @@ final class Printer implements \PHPUnit\TextUI\ResultPrinter
     public function printResult(\PHPUnit\Framework\TestResult $result): void
     {
         if ($result->count() === 0) {
-            $this->style->writeWarning('No tests executed');
+            $this->style->writeWarning('No tests executed!');
         }
 
         $this->style->writeCurrentTestCaseSummary($this->state);

--- a/src/Adapters/Phpunit/Printer.php
+++ b/src/Adapters/Phpunit/Printer.php
@@ -229,6 +229,10 @@ final class Printer implements \PHPUnit\TextUI\ResultPrinter
      */
     public function printResult(\PHPUnit\Framework\TestResult $result): void
     {
+        if ($result->count() === 0) {
+            $this->style->writeWarning('No tests executed');
+        }
+
         $this->style->writeCurrentTestCaseSummary($this->state);
 
         if ($this->failed) {

--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -158,6 +158,13 @@ final class Style
     }
 
     /**
+     * Displays a warning message.
+     */
+    public function writeWarning(string $message) {
+        $this->output->writeln($this->testLineFrom('yellow', $message, ''));
+    }
+
+    /**
      * Displays the error using Collision's writer
      * and terminates with exit code === 1.
      */

--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -160,7 +160,8 @@ final class Style
     /**
      * Displays a warning message.
      */
-    public function writeWarning(string $message) {
+    public function writeWarning(string $message): void 
+    {
         $this->output->writeln($this->testLineFrom('yellow', $message, ''));
     }
 

--- a/tests/Unit/Adapters/PhpunitTest.php
+++ b/tests/Unit/Adapters/PhpunitTest.php
@@ -120,6 +120,20 @@ EOF,
     }
 
     /** @test */
+    public function it_informs_the_user_when_no_tests_are_executed(): void
+    {
+        $output = $this->runCollisionTests([
+            '--filter',
+            'non_existing_test',
+        ]);
+
+        $this->assertConsoleOutputContainsString(
+            'No tests executed',
+            $output
+        );
+    }
+
+    /** @test */
     public function it_has_failure(): void
     {
         $output = $this->runCollisionTests([], 1);

--- a/tests/Unit/Adapters/PhpunitTest.php
+++ b/tests/Unit/Adapters/PhpunitTest.php
@@ -128,7 +128,7 @@ EOF,
         ]);
 
         $this->assertConsoleOutputContainsString(
-            'No tests executed',
+            'No tests executed!',
             $output
         );
     }


### PR DESCRIPTION
I noticed in a Laravel project that the "No tests executed" message is not output when using the `php artisan test` command and hence the Collision Printer. I didn't realize what happened and thought that the test-runner crashed, and so this PR adds a `No tests executed!` as shown below.

Before (notice the complete lack of output):

![image](https://user-images.githubusercontent.com/25909128/93113515-935dc480-f6b9-11ea-9d4a-180309d2c4a6.png)

After:
![image](https://user-images.githubusercontent.com/25909128/93113433-7923e680-f6b9-11ea-9bf7-1012860e564c.png)




