### PR TITLE
fix: use extends instead of implements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,9 @@
         "phpstan/phpstan": "^0.12.36",
         "phpunit/phpunit": "^9.3.3"
     },
+    "conflict": {
+        "phpunit/phpunit": "<9.0"
+    },
     "autoload-dev": {
         "psr-4": {
             "Tests\\Unit\\": "tests/Unit",


### PR DESCRIPTION
I was trying to use collision as printer adapter on a Lumen project. It turned out with the following error:

`NunoMaduro\Collision\Adapters\Phpunit\Printer cannot implement \PHPUnit\TextUI\ResultPrinter. It's not an interface`

Digging deeper into the code, seems that `\PHPUnit\TextUI\ResultPrinter` it's not an interface but a real class.

```
Lumen (7.2.1) (Laravel Components ^7.0)
PhpUnit version 8.5
```