### PR TITLE
Changes to allow the extension of the Collision PHPUnit Printer

### DIFF
--- a/src/Adapters/Phpunit/Printer.php
+++ b/src/Adapters/Phpunit/Printer.php
@@ -13,12 +13,13 @@ use PHPUnit\Framework\Warning;
 use ReflectionObject;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Throwable;
 
 /**
  * @internal
  */
-final class Printer implements \PHPUnit\TextUI\ResultPrinter
+class Printer implements \PHPUnit\TextUI\ResultPrinter
 {
     /**
      * Holds an instance of the style.
@@ -58,7 +59,7 @@ final class Printer implements \PHPUnit\TextUI\ResultPrinter
      *
      * @throws \ReflectionException
      */
-    public function __construct(\Symfony\Component\Console\Output\ConsoleOutputInterface $output = null, bool $verbose = false, string $colors = 'always')
+    public function __construct(ConsoleOutputInterface $output = null, bool $verbose = false, string $colors = 'always')
     {
         $this->timer = Timer::start();
 
@@ -68,11 +69,20 @@ final class Printer implements \PHPUnit\TextUI\ResultPrinter
 
         ConfigureIO::of(new ArgvInput(), $output);
 
-        $this->style = new Style($output);
-        $dummyTest   = new class() extends TestCase {
+        $this->style = $this->newStyle($output);
+
+        $dummyTest = new class() extends TestCase {
         };
 
         $this->state = State::from($dummyTest);
+    }
+
+    /**
+     * Creates a new instance of the Style class.
+     */
+    protected function newStyle(ConsoleOutputInterface $output): Style
+    {
+        return new Style($output);
     }
 
     /**

--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -17,12 +17,12 @@ use Whoops\Exception\Inspector;
 /**
  * @internal
  */
-final class Style
+class Style
 {
     /**
      * @var ConsoleOutput
      */
-    private $output;
+    protected $output;
 
     /**
      * Style constructor.
@@ -160,7 +160,7 @@ final class Style
     /**
      * Displays a warning message.
      */
-    public function writeWarning(string $message): void 
+    public function writeWarning(string $message): void
     {
         $this->output->writeln($this->testLineFrom('yellow', $message, ''));
     }


### PR DESCRIPTION
This change allows the extension of the Collision PHPUnit Printer class including its Style class.

The intention is to add the possibility of extending both classes in order to customise or extend the output of Collision - in a similar way that it's possible to extend & customise the default PHPUnit printer.

With this change I can add a "See in Enlighten" link to Collision:

<img width="1431" alt="Screenshot 2020-10-23 at 13 44 12" src="https://user-images.githubusercontent.com/237530/97005083-d7a07800-1535-11eb-9161-bbc193bb6814.png">

Notice it's not possible to add the link using the PHPUnit basic extensions as the link needs to be printed after the output of the failed tests.

