### PR TITLE
Replace abandoned packages in v3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^7.2.5 || ^8.0",
         "filp/whoops": "^2.1.4",
         "symfony/console": "~2.8|~3.3|~4.0",
-        "jakub-onderka/php-console-highlighter": "0.3.*|0.4.*"
+        "php-parallel-lint/php-console-highlighter": "0.5.*"
     },
     "require-dev": {
         "laravel/framework": "^6.0",


### PR DESCRIPTION
replace abandoned package jakub-onderka/php-console-highlighter with "php-parallel-lint/php-console-highlighter 0.5

closes https://github.com/nunomaduro/collision/issues/172