### PR TITLE
ci: don't test on unsupported PHP 7.3

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -16,14 +16,14 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: 7.4
-        tools: composer:v2
+        tools: composer
         coverage: none
 
     - name: Install Dependencies
-      run: composer update --no-interaction --prefer-dist --no-progress
+      run: composer update --no-interaction --prefer-dist --no-progress --ansi
 
     - name: Run PHP-CS-Fixer
-      run: vendor/bin/php-cs-fixer fix -v --allow-risky=yes --dry-run
+      run: vendor/bin/php-cs-fixer fix -v --allow-risky=yes --dry-run --ansi
 
   phpstan:
     runs-on: ubuntu-latest
@@ -41,11 +41,11 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: 7.4
-        tools: composer:v2
+        tools: composer
         coverage: none
 
     - name: Install Dependencies
-      run: composer update --prefer-stable --no-interaction --prefer-dist --no-progress
+      run: composer update --prefer-stable --no-interaction --prefer-dist --no-progress --ansi
 
     - name: Run PHPStan
-      run: vendor/bin/phpstan analyse --no-progress
+      run: vendor/bin/phpstan analyse --no-progress --ansi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: tests
+name: Tests
 
 on:
   push:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4, 8.0]
+        php: [7.4, 8.0]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} ${{ matrix.dependency-version }}
@@ -25,7 +25,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
-        tools: composer:v2 
+        tools: composer
         coverage: none
 
     - name: Setup Problem Matchers
@@ -33,14 +33,8 @@ jobs:
         echo "::add-matcher::${{ runner.tool_cache }}/php.json"
         echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-
-    - name: Install PHP 7 dependencies
-      run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist --no-progress
-      if: "matrix.php < 8"
-
-    - name: Install PHP 8 dependencies
-      run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist --no-progress --ignore-platform-req=php
-      if: "matrix.php >= 8"
+    - name: Install PHP dependencies
+      run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist --no-progress --ansi
 
     - name: Run Unit Tests
-      run: vendor/bin/phpunit
+      run: vendor/bin/phpunit --colors=always


### PR DESCRIPTION
Laravel 9, which is used for the tests, doesn't support PHP 7.3 and is causing the CI to fail:
https://github.com/nunomaduro/collision/runs/1859433165

This also renames the `Tests` workflow to uppercase to match the badge in the README which has been showing "passing" for a while, even though CI is failing. It also updates to use the `--ansi` flag for CI tasks so that they have coloured output.

The split installs for PHP 7/8 are now also no longer necessary as all dependencies now support PHP 8. 👍🏻