### PR TITLE
Support symfony/console 4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,17 +17,17 @@
         "php": "^7.3 || ^8.0",
         "facade/ignition-contracts": "^1.0",
         "filp/whoops": "^2.7.2",
-        "symfony/console": "^5.0"
+        "symfony/console": "^4.4 | ^5.0"
     },
     "require-dev": {
         "brianium/paratest": "^6.1",
         "fideloper/proxy": "^4.4.1",
         "friendsofphp/php-cs-fixer": "^2.17.3",
         "fruitcake/laravel-cors": "^2.0.3",
-        "laravel/framework": "^9.0",
+        "laravel/framework": "^6.0 | ^7.0 | ^8.0 | ^9.0",
         "nunomaduro/larastan": "^0.6.2",
         "nunomaduro/mock-final-classes": "^1.0",
-        "orchestra/testbench": "^7.0",
+        "orchestra/testbench": "^4.0 | ^5.0 | ^6.0 | ^7.0",
         "phpstan/phpstan": "^0.12.64",
         "phpunit/phpunit": "^9.5.0"
     },

--- a/tests/Unit/Adapters/ArtisanTestCommandTest.php
+++ b/tests/Unit/Adapters/ArtisanTestCommandTest.php
@@ -48,6 +48,15 @@ EOF
         // $this->runTests(['./tests/LaravelApp/artisan', 'test', '--parallel', '--recreate-databases', '--group', 'environmentTesting']);
     }
 
+    protected function setUp(): void
+    {
+        if ((int) \Illuminate\Foundation\Application::VERSION[0] < 8) {
+            $this->markTestSkipped(
+                'Running Collision ^5.0 artisan test command requires at least Laravel ^8.0.'
+            );
+        }
+    }
+
     /**
      * @afterClass
      */


### PR DESCRIPTION
Symfony 4.4 is LTS release and will be supported until November 2023
It is too early to drop support for it.

Fixes #155
