### PR TITLE
Add symfony phpunit bridge and sulu cms directories to ignore files

### DIFF
--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -184,10 +184,10 @@ final class Style
             '/vendor\/mockery\/mockery/',
             '/vendor\/laravel\/dusk/',
             '/vendor\/laravel\/framework\/src\/Illuminate\/Testing/',
-            '/vendor\/laravel\/framework\/src\/Illuminate\/Foundation\/Testing/',
             '/vendor\/symfony\/phpunit-bridge/',
             '/vendor\/bin\/.phpunit/',
             '/bin\/.phpunit/',
+            '/vendor\/sulu\/sulu\/src\/Sulu\/Bundle\/TestBundle\/Testing/',
         ]);
 
         if ($throwable instanceof ExceptionWrapper && $throwable->getOriginalException() !== null) {

--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -184,6 +184,7 @@ final class Style
             '/vendor\/mockery\/mockery/',
             '/vendor\/laravel\/dusk/',
             '/vendor\/laravel\/framework\/src\/Illuminate\/Testing/',
+            '/vendor\/laravel\/framework\/src\/Illuminate\/Foundation\/Testing/',
             '/vendor\/symfony\/phpunit-bridge/',
             '/vendor\/bin\/.phpunit/',
             '/bin\/.phpunit/',

--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -185,6 +185,9 @@ final class Style
             '/vendor\/laravel\/dusk/',
             '/vendor\/laravel\/framework\/src\/Illuminate\/Testing/',
             '/vendor\/laravel\/framework\/src\/Illuminate\/Foundation\/Testing/',
+            '/vendor\/symfony\/phpunit-bridge/',
+            '/vendor\/bin\/.phpunit/',
+            '/bin\/.phpunit/',
         ]);
 
         if ($throwable instanceof ExceptionWrapper && $throwable->getOriginalException() !== null) {


### PR DESCRIPTION
When using the symfony phpunit bridge. PHPunit maybe exist in some of this directories. Also added the Testing directory of @sulu as needed from our side.