### PR TITLE
Add Symfony PhpUnit recipe files to ignore files

### DIFF
--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -188,6 +188,8 @@ final class Style
             '/vendor\/symfony\/phpunit-bridge/',
             '/vendor\/bin\/.phpunit/',
             '/bin\/.phpunit/',
+            '/vendor\/bin\/simple-phpunit/',
+            '/bin\/phpunit/',
             '/vendor\/sulu\/sulu\/src\/Sulu\/Bundle\/TestBundle\/Testing/',
         ]);
 


### PR DESCRIPTION
The symfony recipe create or phpunit bridge creates a `bin/phpunit` file which should also add to ignore stack trace. In bundles also the symlinked `vendor/bin/simple-phpunit` script is sometimes used so also this should be ignored.