### PR TITLE
Add possibility for custom ignoreFilesIn path

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ Add the Collision `printerClass` to your `phpunit.xml` in the `phpunit` section:
         printerClass="NunoMaduro\Collision\Adapters\Phpunit\Printer">
 ```
 
+### Ignore files from Stacktrace
+
+If you want to ignore specific Files or whole directory from the Printer Stack trace
+you can add the following to your `phpunit.xml`.
+
+```xml
+    <php>
+        <server name="COLLISION_PRINTER_IGNORE_FILES_IN" value="/tests\/Traits\/AssertSnapshotTrait.php/,/tests\/Traits\/OtherTrait.php/"/>
+    </php>
+```
+
 ## No adapter
 
 You need to register the handler in your code:

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ Add the Collision `printerClass` to your `phpunit.xml` in the `phpunit` section:
 
 ### Ignore files from Stacktrace
 
-If you want to ignore specific Files or whole directory from the Printer Stack trace
-you can add the following to your `phpunit.xml`.
+If you have custom Assert methods which should be ignored by the Printer Stack trace the
+files or directories which should be ignored can be added the following way to the
+`phpunit.xml` file.
 
 ```xml
     <php>

--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -178,8 +178,9 @@ final class Style
             $this->output->write('', true);
         }
 
-        $writer->ignoreFilesIn([
+        $ignoreFilesIn = [
             '/vendor\/pestphp\/pest/',
+            '/vendor\/phpspec\/prophecy-phpunit/',
             '/vendor\/phpunit\/phpunit\/src/',
             '/vendor\/mockery\/mockery/',
             '/vendor\/laravel\/dusk/',
@@ -191,7 +192,14 @@ final class Style
             '/vendor\/bin\/simple-phpunit/',
             '/bin\/phpunit/',
             '/vendor\/sulu\/sulu\/src\/Sulu\/Bundle\/TestBundle\/Testing/',
-        ]);
+        ];
+
+        $customIgnoreFilesIn = $_SERVER['COLLISION_PRINTER_IGNORE_FILES_IN'] ?? $_ENV['COLLISION_PRINTER_IGNORE_FILES_IN'] ?? null;
+        if ($customIgnoreFilesIn) {
+            $ignoreFilesIn = \array_merge($ignoreFilesIn, array_filter(explode(',', $customIgnoreFilesIn)));
+        }
+
+        $writer->ignoreFilesIn($ignoreFilesIn);
 
         if ($throwable instanceof ExceptionWrapper && $throwable->getOriginalException() !== null) {
             $throwable = $throwable->getOriginalException();

--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -180,7 +180,6 @@ final class Style
 
         $ignoreFilesIn = [
             '/vendor\/pestphp\/pest/',
-            '/vendor\/phpspec\/prophecy-phpunit/',
             '/vendor\/phpunit\/phpunit\/src/',
             '/vendor\/mockery\/mockery/',
             '/vendor\/laravel\/dusk/',


### PR DESCRIPTION
It would be nice to had the possibility to add custom Traits to the ignoreFileIn Path e.g.:

```xml
<?xml version="1.0" encoding="UTF-8"?>

<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="bin/.phpunit/phpunit.xsd"
         backupGlobals="false"
         colors="true"
         bootstrap="tests/bootstrap.php"
         printerClass="NunoMaduro\Collision\Adapters\Phpunit\Printer"
>
    <php>
        <server name="COLLISION_PRINTER_IGNORE_FILES_IN" value="/tests\/Fucntional\/AssertSnapshotTrait.php/,/tests\/Fucntional\/TestTrait.php/"/>
    </php>

    <!-- .. -->
</phpunit>

```