### PR TITLE
Add phpspec/prophecy-phpunit to ignoreFilesIn

### DIFF
--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -180,6 +180,7 @@ final class Style
 
         $writer->ignoreFilesIn([
             '/vendor\/pestphp\/pest/',
+            '/vendor\/phpspec\/prophecy-phpunit/',
             '/vendor\/phpunit\/phpunit\/src/',
             '/vendor\/mockery\/mockery/',
             '/vendor\/laravel\/dusk/',


### PR DESCRIPTION
Could not reproduce this one but think this directory should also be excluded from the printer.