### PR TITLE
Add Symfony custom Assertion to ignoreFilesIn

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "fideloper/proxy": "^4.4.1",
         "friendsofphp/php-cs-fixer": "^2.17.3",
         "fruitcake/laravel-cors": "^2.0.3",
-        "laravel/framework": "^9.0",
+        "laravel/framework": "^8.0 || ^9.0",
         "nunomaduro/larastan": "^0.6.2",
         "nunomaduro/mock-final-classes": "^1.0",
         "orchestra/testbench": "^7.0",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "laravel/framework": "^8.0 || ^9.0",
         "nunomaduro/larastan": "^0.6.2",
         "nunomaduro/mock-final-classes": "^1.0",
-        "orchestra/testbench": "^7.0",
+        "orchestra/testbench": "^6.0 || ^7.0",
         "phpstan/phpstan": "^0.12.64",
         "phpunit/phpunit": "^9.5.0"
     },

--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -185,6 +185,7 @@ final class Style
             '/vendor\/laravel\/dusk/',
             '/vendor\/laravel\/framework\/src\/Illuminate\/Testing/',
             '/vendor\/laravel\/framework\/src\/Illuminate\/Foundation\/Testing/',
+            '/vendor\/symfony\/framework-bundle\/Test/',
             '/vendor\/symfony\/phpunit-bridge/',
             '/vendor\/bin\/.phpunit/',
             '/bin\/.phpunit/',


### PR DESCRIPTION
Symfony has some custom assertion methods which should also be added to the ignoreFilesIn so the output does point to the correct location: https://github.com/symfony/framework-bundle/tree/5.3/Test

Example:

```php
        $client = static::createClient();

        $client->request('GET', '/');
        $this->assertResponseRedirects('/login', 302);
```