### PR TITLE
Add ideLink for printed test results

### DIFF
--- a/src/Adapters/Phpunit/TestResult.php
+++ b/src/Adapters/Phpunit/TestResult.php
@@ -66,6 +66,13 @@ final class TestResult
     /**
      * @readonly
      *
+     * @var string|null
+     */
+    public $ideLink;
+
+    /**
+     * @readonly
+     *
      * @var string
      */
     public $warning = '';
@@ -73,7 +80,7 @@ final class TestResult
     /**
      * Test constructor.
      */
-    private function __construct(string $testCaseName, string $description, string $type, string $icon, string $color, Throwable $throwable = null)
+    private function __construct(string $testCaseName, string $description, string $type, string $icon, string $color, Throwable $throwable = null, ?string $ideLink = null)
     {
         $this->testCaseName = $testCaseName;
         $this->description  = $description;
@@ -81,6 +88,7 @@ final class TestResult
         $this->icon         = $icon;
         $this->color        = $color;
         $this->throwable    = $throwable;
+        $this->ideLink      = $ideLink;
 
         $asWarning = $this->type === TestResult::WARN
              || $this->type === TestResult::RISKY
@@ -105,7 +113,16 @@ final class TestResult
 
         $color = self::makeColor($type);
 
-        return new self($testCaseName, $description, $type, $icon, $color, $throwable);
+        $ideLink = null;
+
+        if (\class_exists($testCaseName) && $fileLinkFormat = ini_get('xdebug.file_link_format')) {
+            $reflectionClass  = new \ReflectionClass($testCaseName);
+            $fileName         = $reflectionClass->getFileName();
+            $methodReflection = $reflectionClass->getMethod($testCase->getName());
+            $ideLink          = str_replace(['%f', '%l'], [$fileName, $methodReflection->getStartLine()], $fileLinkFormat);
+        }
+
+        return new self($testCaseName, $description, $type, $icon, $color, $throwable, $ideLink);
     }
 
     /**


### PR DESCRIPTION
Currently its sometimes hard when you run all tests and see that example test `find by country and location` is failing to get to the method call `testFindByCountryAndLocation` failing as you can not simple copy it from somewhere in the output.

This pull request tries to solve this issue by make use of the [xdebug configuration](https://xdebug.org/docs/all_settings#file_link_format) and the [console href links](https://symfony.com/blog/new-in-symfony-4-3-console-hyperlinks) that the results are linked to the runned tests.

The `xdebug` support to configure a link format which can be used that printed stack trace is directly linked to the ide you are using:

```ini
xdebug.file_link_format = "phpstorm://open?file=%f&line=%l"
```

If this is now configured the output of the printer will link directly to the methods and so you can just click on them.


**New output** with clickable links:

<img width="514" alt="Bildschirmfoto 2021-07-28 um 00 56 43" src="https://user-images.githubusercontent.com/1698337/127237962-4aa7458d-b19d-4655-90d1-0f830adbdba8.png">

<details>

<summary>Old output</summary>

<img width="530" alt="Bildschirmfoto 2021-07-28 um 00 57 29" src="https://user-images.githubusercontent.com/1698337/127238008-45af3848-3dc6-482d-8766-b6fd972973d1.png">

</details>
