### PR TITLE
Add colored diff between expected and actual

### DIFF
--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -205,7 +205,20 @@ final class Style
 
         if ($throwable instanceof ExpectationFailedException && $comparisionFailure = $throwable->getComparisonFailure()) {
             $diff  = $comparisionFailure->getDiff();
+            $lines = explode(PHP_EOL, $diff);
+            $diff  = '';
+            foreach ($lines as $line) {
+                if (0 === strpos($line, '-')) {
+                    $line = '<fg=red>' . $line . '</>';
+                } elseif (0 === strpos($line, '+')) {
+                    $line = '<fg=green>' . $line . '</>';
+                }
+
+                $diff .= $line . PHP_EOL;
+            }
+
             $diff  = trim((string) preg_replace("/\r|\n/", "\n  ", $diff));
+
             $this->output->write("  $diff");
         }
 


### PR DESCRIPTION
Currently the diff between 2 arrays is shown this way:


<details>
<summary>Code Example</summary>

```php

        $this->assertSame(
            [
                'firstName' => 'Hikaru',
                'lastName' => 'Sulu',
                'Street' => '12',
                'Country' => 'Austria',
                'phone' => '123',
            ],
            [
                'firstName' => 'Hikaru',
                'lastName' => 'Sulu',
                'Street' => '20',
                'Country' => 'Austria',
                'phone' => '27',
            ]
        );
```

</details>


<img width="260" alt="Bildschirmfoto 2021-07-28 um 01 14 16" src="https://user-images.githubusercontent.com/1698337/127239325-096f8d31-0eaa-4a15-94d1-2aeb2d6781a2.png">

Instead I thought it would be nice to use also colors here and printing it this way:

<img width="261" alt="Bildschirmfoto 2021-07-28 um 01 15 15" src="https://user-images.githubusercontent.com/1698337/127239378-596197e6-2890-492a-b53b-74d76a864961.png">

This helps specially when using the [coduo-php-matcher](https://github.com/coduo/php-matcher) for api endpoints with big arrays.
