### PR TITLE
Updates php-cs-fixer to use latest version changes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,7 +4,7 @@
 .editorconfig      export-ignore
 .gitattributes     export-ignore
 .gitignore         export-ignore
-.php_cs            export-ignore
+.php-cs-fixer.php  export-ignore
 .scrutinizer.yml   export-ignore
 .styleci.yml       export-ignore
 phpunit.xml.dist   export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ composer.lock
 /vendor/
 coverage.xml
 .phpunit.result.cache
-.php_cs.cache
+.php-cs-fixer.cache

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -29,7 +29,7 @@ $rules = [
 
 $rules['increment_style'] = ['style' => 'post'];
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setUsingCache(true)
     ->setRules($rules)
     ->setFinder($finder);

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -6,7 +6,7 @@ $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__ . DIRECTORY_SEPARATOR . 'tests')
     ->notPath(__DIR__ . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'laravel')
     ->in(__DIR__ . DIRECTORY_SEPARATOR . 'src')
-    ->append(['.php_cs']);
+    ->append(['.php-cs-fixer.php']);
 
 $rules = [
     '@Symfony'               => true,

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "brianium/paratest": "^6.1",
         "fideloper/proxy": "^4.4.1",
-        "friendsofphp/php-cs-fixer": "^2.17.3",
+        "friendsofphp/php-cs-fixer": "^3.0",
         "fruitcake/laravel-cors": "^2.0.3",
         "laravel/framework": "^8.0 || ^9.0",
         "nunomaduro/larastan": "^0.6.2",

--- a/src/ConsoleColor.php
+++ b/src/ConsoleColor.php
@@ -12,12 +12,12 @@ use NunoMaduro\Collision\Exceptions\ShouldNotHappen;
  */
 final class ConsoleColor
 {
-    const FOREGROUND = 38;
-    const BACKGROUND = 48;
+    public const FOREGROUND = 38;
+    public const BACKGROUND = 48;
 
-    const COLOR256_REGEXP = '~^(bg_)?color_(\d{1,3})$~';
+    public const COLOR256_REGEXP = '~^(bg_)?color_(\d{1,3})$~';
 
-    const RESET_STYLE = 0;
+    public const RESET_STYLE = 0;
 
     /** @var bool */
     private $isSupported;

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -26,7 +26,7 @@ final class Writer implements WriterContract
     /**
      * The number of frames if no verbosity is specified.
      */
-    const VERBOSITY_NORMAL_FRAMES = 1;
+    public const VERBOSITY_NORMAL_FRAMES = 1;
 
     /**
      * Holds an instance of the solutions repository.


### PR DESCRIPTION
Howdy!

Keep getting this when working on other things for collision, so wanted to update it whilst it in a separate PR. Basically just updates the filename to use the latest version of the cs-fixer and updates a deprecated use of class initialisation.

Kind Regards,
Luke
