### PR TITLE
Adds greater support for Pest console options

### DIFF
--- a/src/Adapters/Laravel/Commands/TestCommand.php
+++ b/src/Adapters/Laravel/Commands/TestCommand.php
@@ -120,23 +120,17 @@ class TestCommand extends Command
      */
     protected function binary()
     {
-        switch (true) {
-            case $this->option('parallel'):
-                $command = 'vendor/brianium/paratest/bin/paratest';
-                break;
-            case class_exists(\Pest\Laravel\PestServiceProvider::class):
-                $command = 'vendor/pestphp/pest/bin/pest';
-                break;
-            default:
-                $command = 'vendor/phpunit/phpunit/phpunit';
-                break;
+        if (class_exists(\Pest\Laravel\PestServiceProvider::class)) {
+            $command = $this->option('parallel') ? ['vendor/pestphp/pest/bin/pest', '--parallel'] : ['vendor/pestphp/pest/bin/pest'];
+        } else {
+            $command = $this->option('parallel') ? ['vendor/brianium/paratest/bin/paratest'] : ['vendor/phpunit/phpunit/phpunit'];
         }
 
         if ('phpdbg' === PHP_SAPI) {
-            return [PHP_BINARY, '-qrr', $command];
+            return array_merge([PHP_BINARY, '-qrr'], $command);
         }
 
-        return [PHP_BINARY, $command];
+        return array_merge([PHP_BINARY], $command);
     }
 
     /**


### PR DESCRIPTION
This PR adds support for Pest's parallel testing option by calling the `./vendor/bin/pest --parallel` command if Pest is installed and the `--parallel` option is present.