### PR TITLE
Allows a custom Writer to be set on the PhpUnit adapter

### DIFF
--- a/src/ConsoleColor.php
+++ b/src/ConsoleColor.php
@@ -205,6 +205,11 @@ final class ConsoleColor
      */
     public function isSupported()
     {
+        // The COLLISION_FORCE_COLORS variable is for internal purposes only
+        if (getenv('COLLISION_FORCE_COLORS') !== false) {
+            return true;
+        }
+
         if (DIRECTORY_SEPARATOR === '\\') {
             return getenv('ANSICON') !== false || getenv('ConEmuANSI') === 'ON';
         }


### PR DESCRIPTION
> This is a vastly simplified version of https://github.com/nunomaduro/collision/pull/192

Happy Wednesday!

Up until now, the Writer on the PhpUnit Printer for Collision was instantiated by the class itself. For Pest parallel, we need to be able to set a custom writer that allows us to force the colour style in the highlighter to get syntax highlighting on test errors.

This PR add a new setStyleWriter method on the Printer, which allows for an override of the default writer.

Kind Regards,
Luke