### PR TITLE
Add symfony dom crawler and browser kit to ignoreFiles for stack trace

### DIFF
--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -187,6 +187,8 @@ final class Style
             '/vendor\/laravel\/framework\/src\/Illuminate\/Foundation\/Testing/',
             '/vendor\/symfony\/framework-bundle\/Test/',
             '/vendor\/symfony\/phpunit-bridge/',
+            '/vendor\/symfony\/dom-crawler/',
+            '/vendor\/symfony\/browser-kit/',
             '/vendor\/bin\/.phpunit/',
             '/bin\/.phpunit/',
             '/vendor\/bin\/simple-phpunit/',


### PR DESCRIPTION
**Before:**

<img width="672" alt="Bildschirmfoto 2021-11-08 um 19 54 49" src="https://user-images.githubusercontent.com/1698337/140800972-79323b98-38ff-4a98-9df3-9bf1d8226951.png">

**After:**

<img width="668" alt="Bildschirmfoto 2021-11-08 um 19 54 24" src="https://user-images.githubusercontent.com/1698337/140800983-2a6a1802-b51b-48ae-a4ac-5b2b0d9e7dfb.png">

