### PR TITLE
Adds support for showing additional details when presenting exceptions

### DIFF
--- a/src/Adapters/Laravel/CollisionServiceProvider.php
+++ b/src/Adapters/Laravel/CollisionServiceProvider.php
@@ -7,6 +7,7 @@ namespace NunoMaduro\Collision\Adapters\Laravel;
 use Illuminate\Contracts\Debug\ExceptionHandler as ExceptionHandlerContract;
 use Illuminate\Support\ServiceProvider;
 use NunoMaduro\Collision\Adapters\Laravel\Commands\TestCommand;
+use NunoMaduro\Collision\Contracts\FurtherDetailWriter;
 use NunoMaduro\Collision\Contracts\Provider as ProviderContract;
 use NunoMaduro\Collision\Handler;
 use NunoMaduro\Collision\Provider;
@@ -44,6 +45,8 @@ class CollisionServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->app->bind(FurtherDetailWriter::class, LaravelFurtherDetailWriter::class);
+
         if ($this->app->runningInConsole() && !$this->app->runningUnitTests()) {
             $this->app->bind(ProviderContract::class, function () {
                 if ($this->app->has(\Facade\IgnitionContracts\SolutionProviderRepository::class)) {
@@ -54,7 +57,13 @@ class CollisionServiceProvider extends ServiceProvider
                     $solutionsRepository = new NullSolutionsRepository();
                 }
 
-                $writer = new Writer($solutionsRepository);
+                $writer = new Writer(
+                    $solutionsRepository,
+                    null,
+                    null,
+                    null,
+                    $this->app->make(FurtherDetailWriter::class),
+                );
                 $handler = new Handler($writer);
 
                 return new Provider(null, $handler);
@@ -76,6 +85,9 @@ class CollisionServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return [ProviderContract::class];
+        return [
+            ProviderContract::class,
+            FurtherDetailWriter::class,
+        ];
     }
 }

--- a/src/Adapters/Laravel/LaravelFurtherDetailWriter.php
+++ b/src/Adapters/Laravel/LaravelFurtherDetailWriter.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Collision\Adapters\Laravel;
+
+use Illuminate\Validation\ValidationException;
+use NunoMaduro\Collision\Contracts\FurtherDetailWriter;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+final class LaravelFurtherDetailWriter implements FurtherDetailWriter
+{
+    /**
+     * Exceptions that should be handled.
+     *
+     * @var array<class-string, string>
+     */
+    private $exceptionsWithFurtherDetail = [
+        ValidationException::class => 'handleValidationException',
+    ];
+
+    public function write(OutputInterface $output, Throwable $throwable): void
+    {
+        if ($throwable instanceof ValidationException) {
+            $this->handleValidationException($output, $throwable);
+        }
+    }
+
+    public function handleValidationException(OutputInterface $output, ValidationException $throwable): void
+    {
+        $output->writeln('');
+        $output->writeln('  The exception contains the following validation errors:');
+        $output->writeln('');
+        $output->writeln('  [');
+
+        foreach ($throwable->errors() as $key => $errors) {
+            $output->writeln("    <fg=red>'{$key}'</> => [");
+            foreach ($errors as $message) {
+                $output->writeln("      <fg=default>'{$message}'</>,");
+            }
+            $isLastError = array_reverse(array_keys($throwable->errors()))[0] === $key;
+            $output->writeln($isLastError ? '    ]' : '    ],');
+        }
+
+        $output->writeln('  ];');
+        $output->writeln('');
+    }
+}

--- a/src/Adapters/Laravel/LaravelFurtherDetailWriter.php
+++ b/src/Adapters/Laravel/LaravelFurtherDetailWriter.php
@@ -11,7 +11,6 @@ use Throwable;
 
 final class LaravelFurtherDetailWriter implements FurtherDetailWriter
 {
-
     public function write(OutputInterface $output, Throwable $throwable): void
     {
         if ($throwable instanceof ValidationException) {

--- a/src/Adapters/Laravel/LaravelFurtherDetailWriter.php
+++ b/src/Adapters/Laravel/LaravelFurtherDetailWriter.php
@@ -11,14 +11,6 @@ use Throwable;
 
 final class LaravelFurtherDetailWriter implements FurtherDetailWriter
 {
-    /**
-     * Exceptions that should be handled.
-     *
-     * @var array<class-string, string>
-     */
-    private $exceptionsWithFurtherDetail = [
-        ValidationException::class => 'handleValidationException',
-    ];
 
     public function write(OutputInterface $output, Throwable $throwable): void
     {

--- a/src/Contracts/FurtherDetailWriter.php
+++ b/src/Contracts/FurtherDetailWriter.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Collision\Contracts;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+interface FurtherDetailWriter
+{
+    public function write(OutputInterface $output, Throwable $throwable): void;
+}

--- a/src/FurtherDetailRepositories/NullFurtherDetailWriter.php
+++ b/src/FurtherDetailRepositories/NullFurtherDetailWriter.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Collision\FurtherDetailRepositories;
+
+use NunoMaduro\Collision\Contracts\FurtherDetailWriter;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+final class NullFurtherDetailWriter implements FurtherDetailWriter
+{
+
+    public function write(OutputInterface $output, Throwable $throwable): void
+    {
+    }
+}

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -348,8 +348,7 @@ final class Writer implements WriterContract
      *
      * @return $this
      */
-    protected function
-    render(string $message, bool $break = true): WriterContract
+    protected function render(string $message, bool $break = true): WriterContract
     {
         if ($break) {
             $this->output->writeln('');

--- a/tests/LaravelApp/app/Console/Commands/CommandThatValidates.php
+++ b/tests/LaravelApp/app/Console/Commands/CommandThatValidates.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Validator;
+
+class CommandThatValidates extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'command-that-validates';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'This command will throw a validation exception';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle(): int
+    {
+        Validator::make(['foo' => 'bar', 'baz' => null], [
+            'foo' => ['integer', 'numeric'],
+            'baz' => ['required', 'string']
+        ])->validate();
+
+        return Command::FAILURE;
+    }
+}

--- a/tests/LaravelApp/config/app.php
+++ b/tests/LaravelApp/config/app.php
@@ -165,6 +165,7 @@ return [
         /*
          * Package Service Providers...
          */
+        NunoMaduro\Collision\Adapters\Laravel\CollisionServiceProvider::class,
 
         /*
          * Application Service Providers...

--- a/tests/LaravelApp/routes/web.php
+++ b/tests/LaravelApp/routes/web.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Facades\Validator;
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/LaravelApp/routes/web.php
+++ b/tests/LaravelApp/routes/web.php
@@ -19,10 +19,3 @@ use Illuminate\Support\Facades\Validator;
 Route::get('/', function () {
     return view('welcome');
 });
-
-Route::get('/validation-exception', function () {
-    Validator::make(['foo' => 'bar', 'baz' => null], [
-        'foo' => ['integer'],
-        'baz' => ['required', 'string']
-    ])->validate();
-});

--- a/tests/LaravelApp/routes/web.php
+++ b/tests/LaravelApp/routes/web.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Validator;
 
 /*
 |--------------------------------------------------------------------------
@@ -17,4 +18,11 @@ use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
+});
+
+Route::get('/validation-exception', function () {
+    Validator::make(['foo' => 'bar', 'baz' => null], [
+        'foo' => ['integer'],
+        'baz' => ['required', 'string']
+    ])->validate();
 });

--- a/tests/Unit/Adapters/Laravel/LaravelFurtherDetailWriter/IgnoredExceptionTest.php
+++ b/tests/Unit/Adapters/Laravel/LaravelFurtherDetailWriter/IgnoredExceptionTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Unit\Adapters\Laravel\LaravelFurtherDetailWriter;
+
+use Exception;
+use NunoMaduro\Collision\Adapters\Laravel\LaravelFurtherDetailWriter;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class IgnoredExceptionTest extends TestCase
+{
+
+    /** @test */
+    public function itPrintsNothingForUnhandledExceptions()
+    {
+        $output = new BufferedOutput();
+        $writer = new LaravelFurtherDetailWriter();
+
+        $writer->write($output, new Exception());
+
+        $this->assertEquals($output->fetch(), '');
+    }
+
+}

--- a/tests/Unit/Adapters/Laravel/LaravelFurtherDetailWriter/ValidationExceptionTest.php
+++ b/tests/Unit/Adapters/Laravel/LaravelFurtherDetailWriter/ValidationExceptionTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Unit\Adapters\Laravel\LaravelFurtherDetailWriter;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Support\MessageBag;
+use Illuminate\Validation\ValidationException;
+use NunoMaduro\Collision\Adapters\Laravel\LaravelFurtherDetailWriter;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Mockery as m;
+
+class ValidationExceptionTest extends TestCase
+{
+
+    /** @test */
+    public function itOutputsTheValidationErrorsCorrectly()
+    {
+        $exception = $this->getException([
+            'foo' => ['Something went wrong.'],
+            'bar' => ['This is required.', 'It should be an integer.']
+        ]);
+
+        $output = new BufferedOutput();
+        $writer = new LaravelFurtherDetailWriter();
+
+        $writer->write($output, $exception);
+
+        $result = <<<EOF
+
+  The exception contains the following validation errors:
+
+  [
+    'foo' => [
+      'Something went wrong.',
+    ],
+    'bar' => [
+      'This is required.',
+      'It should be an integer.',
+    ]
+  ];
+
+
+EOF;
+
+        $this->assertEquals($output->fetch(), $result);
+    }
+
+    private function getException(array $messages): ValidationException
+    {
+        $validator = m::mock(Validator::class);
+        $validator->shouldReceive('errors')
+            ->andReturn(new MessageBag($messages));
+
+        return new ValidationException($validator);
+    }
+
+}

--- a/tests/Unit/Adapters/LaravelTest.php
+++ b/tests/Unit/Adapters/LaravelTest.php
@@ -11,6 +11,7 @@ use Illuminate\Foundation\Application;
 use NunoMaduro\Collision\Adapters\Laravel\CollisionServiceProvider;
 use NunoMaduro\Collision\Adapters\Laravel\ExceptionHandler;
 use NunoMaduro\Collision\Adapters\Laravel\Inspector;
+use NunoMaduro\Collision\Contracts\FurtherDetailWriter;
 use NunoMaduro\Collision\Contracts\Handler;
 use NunoMaduro\Collision\Contracts\Provider as ProviderContract;
 use PHPUnit\Framework\TestCase;
@@ -137,11 +138,11 @@ class LaravelTest extends TestCase
     }
 
     /** @test */
-    public function itProvidesOnlyTheProviderContract(): void
+    public function itProvidesOnlyTheExpectedContracts(): void
     {
         $app      = $this->createApplication();
         $provides = (new CollisionServiceProvider($app))->provides();
-        $this->assertEquals([ProviderContract::class], $provides);
+        $this->assertEquals([ProviderContract::class, FurtherDetailWriter::class], $provides);
     }
 
     /**


### PR DESCRIPTION
Howdy!

Let's imagine that you have a console command in your Laravel application that uses the `Validator` to verify user input.

Currently, when the exception is thrown, you get a stack trace, which is great, but you don't see any detail as to what the validation errors are. This isn't a brilliant experience if you're not sure what the validation issue is.

In order to improve on this, I've added a new contract: `FurtherDetailWriter`. This writer is null by default, but in a Laravel application, we use a `LaravelFurtherDetailWriter`. The writer receives any exception thrown via its `write` method. This method receives the `$output` and `$throwable` instances. It can then basically write anything to the console it wants.

In the case of the `LaravelFurtherDetailWriter`, we check for a `ValidationException`, loop over the errors returned in that exception, and print each one to the console. Here's an example:

<img width="1069" alt="CleanShot 2021-11-19 at 13 53 02@2x" src="https://user-images.githubusercontent.com/12202279/142634260-8e9e3af1-86ab-46e2-a976-553c7b286384.png">

## Advanced usage

A developer has the option of binding their own `FurtherDetailWriter` into the service container in their Laravel application, which means they can output any additional details they want for custom exceptions thrown in the Laravel container. This actually provides a robust solution for issues like the following:

https://github.com/laravel/framework/issues/23515
https://github.com/nunomaduro/collision/issues/65