### PR TITLE
Extendable Environment Variables in Laravel Test Command

### DIFF
--- a/src/Adapters/Laravel/Commands/TestCommand.php
+++ b/src/Adapters/Laravel/Commands/TestCommand.php
@@ -90,10 +90,7 @@ class TestCommand extends Command
             ),
             null,
             // Envs ...
-            $parallel ? [
-                'LARAVEL_PARALLEL_TESTING'                    => 1,
-                'LARAVEL_PARALLEL_TESTING_RECREATE_DATABASES' => $this->option('recreate-databases'),
-            ] : [],
+            $parallel ? $this->paratestEnvironmentVariables() : $this->phpunitEnvironmentVariables(),
         ))->setTimeout(null);
 
         try {
@@ -179,6 +176,29 @@ class TestCommand extends Command
             "--configuration=$file",
             "--runner=\Illuminate\Testing\ParallelRunner",
         ], $options);
+    }
+
+    /**
+     * Get the array of environment variables for running PHPUnit.
+     *
+     * @return array
+     */
+    protected function phpunitEnvironmentVariables()
+    {
+        return [];
+    }
+
+    /**
+     * Get the array of environment variables for running Paratest.
+     *
+     * @return array
+     */
+    protected function paratestEnvironmentVariables()
+    {
+        return [
+            'LARAVEL_PARALLEL_TESTING'                    => 1,
+            'LARAVEL_PARALLEL_TESTING_RECREATE_DATABASES' => $this->option('recreate-databases'),
+        ];
     }
 
     /**


### PR DESCRIPTION
Hey!

Right now it's not possible to add or modify Environment Variables if you add command arguments by extending `Adapters\Laravel\Commands\TestCommand`.

This PR should make you able to extend TestCommand in Laravel projects to add any arguments you may need during tests.

Example of extended TestCommand:

```php
namespace App\Console\Commands;

use Illuminate\Support\Str;
use NunoMaduro\Collision\Adapters\Laravel\Commands\TestCommand as BaseTestCommand;

class TestCommand extends BaseTestCommand
{
    /**
     * The name and signature of the console command.
     *
     * @var string
     */
    protected $signature = 'test
    {--without-tty : Disable output to TTY}
    {--p|parallel : Indicates if the tests should run in parallel}
    {--recreate-databases : Indicates if the test databases should be re-created}
    {--c|custom-argument : Does some custom stuff}
';

    /**
     * Get the array of environment variables for running PHPUnit.
     *
     * @return array
     */
    protected function phpunitEnvironmentVariables()
    {
        return array_merge(
            parent::phpunitEnvironmentVariables(),
            [
                'CUSTOM_ENV_VARIABLE'                => 1,
                'CUSTOM_ENV_VARIABLE_FOR_PHPUNIT'    => 1,
            ],
        );
    }

    /**
     * Get the array of environment variables for running Paratest.
     *
     * @return array
     */
    protected function paratestEnvironmentVariables()
    {
        return array_merge(
            parent::paratestEnvironmentVariables(),
            [
                'CUSTOM_ENV_VARIABLE'                => 1,
                'CUSTOM_ENV_VARIABLE_FOR_PARALLEL'   => 1,
            ],
        );
    }

    /**
     * Get the array of arguments for running PHPUnit.
     *
     * @param array $options
     *
     * @return array
     */
    protected function phpunitArguments($options)
    {
        return parent::phpunitArguments($this->filterCustomOption($options));
    }

    /**
     * Get the array of arguments for running Paratest.
     *
     * @param array $options
     *
     * @return array
     */
    protected function paratestArguments($options)
    {
        return parent::paratestArguments($this->filterCustomOption($options));
    }

    /**
     * Filters my custom argument from options list.
     *
     * @param array $options
     *
     * @return array
     */
    protected function filterCustomOption($options)
    {
        return array_values(array_filter($options, function ($option) {
            return !Str::startsWith($option, '-c')
                && !Str::startsWith($option, '--custom-argument');
        }));
    }
}

```