### PR TITLE
Extendable Environment Variables in Laravel Test Command with Tests

### DIFF
--- a/src/Adapters/Laravel/Commands/TestCommand.php
+++ b/src/Adapters/Laravel/Commands/TestCommand.php
@@ -90,10 +90,7 @@ class TestCommand extends Command
             ),
             null,
             // Envs ...
-            $parallel ? [
-                'LARAVEL_PARALLEL_TESTING'                    => 1,
-                'LARAVEL_PARALLEL_TESTING_RECREATE_DATABASES' => $this->option('recreate-databases'),
-            ] : [],
+            $parallel ? $this->paratestEnvironmentVariables() : $this->phpunitEnvironmentVariables(),
         ))->setTimeout(null);
 
         try {
@@ -179,6 +176,29 @@ class TestCommand extends Command
             "--configuration=$file",
             "--runner=\Illuminate\Testing\ParallelRunner",
         ], $options);
+    }
+
+    /**
+     * Get the array of environment variables for running PHPUnit.
+     *
+     * @return array
+     */
+    protected function phpunitEnvironmentVariables()
+    {
+        return [];
+    }
+
+    /**
+     * Get the array of environment variables for running Paratest.
+     *
+     * @return array
+     */
+    protected function paratestEnvironmentVariables()
+    {
+        return [
+            'LARAVEL_PARALLEL_TESTING'                    => 1,
+            'LARAVEL_PARALLEL_TESTING_RECREATE_DATABASES' => $this->option('recreate-databases'),
+        ];
     }
 
     /**

--- a/tests/LaravelApp/app/Console/Commands/TestCommand.php
+++ b/tests/LaravelApp/app/Console/Commands/TestCommand.php
@@ -4,10 +4,23 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use Illuminate\Support\Str;
 use NunoMaduro\Collision\Adapters\Laravel\Commands\TestCommand as BaseTestCommand;
 
 class TestCommand extends BaseTestCommand
 {
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'test
+    {--without-tty : Disable output to TTY}
+    {--p|parallel : Indicates if the tests should run in parallel}
+    {--recreate-databases : Indicates if the test databases should be re-created}
+    {--c|custom-argument : Add custom env variable}
+';
+
     /**
      * Get the PHP binary to execute.
      *
@@ -32,5 +45,84 @@ class TestCommand extends BaseTestCommand
         }
 
         return [PHP_BINARY, __DIR__ . '/../../../../../' . $command];
+    }
+
+    /**
+     * Get the array of environment variables for running PHPUnit.
+     *
+     * @return array
+     */
+    protected function phpunitEnvironmentVariables()
+    {
+        if ($this->option("custom-argument")) {
+            return array_merge(
+                parent::phpunitEnvironmentVariables(),
+                [
+                    'CUSTOM_ENV_VARIABLE'                => 1,
+                    'CUSTOM_ENV_VARIABLE_FOR_PHPUNIT'    => 1,
+                ],
+            );
+        }
+
+        return parent::phpunitEnvironmentVariables();
+    }
+
+    /**
+     * Get the array of environment variables for running Paratest.
+     *
+     * @return array
+     */
+    protected function paratestEnvironmentVariables()
+    {
+        if ($this->option("custom-argument")) {
+            return array_merge(
+                parent::paratestEnvironmentVariables(),
+                [
+                    'CUSTOM_ENV_VARIABLE'                => 1,
+                    'CUSTOM_ENV_VARIABLE_FOR_PARALLEL'   => 1,
+                ],
+            );
+        }
+
+        return parent::paratestEnvironmentVariables();
+    }
+
+    /**
+     * Get the array of arguments for running PHPUnit.
+     *
+     * @param array $options
+     *
+     * @return array
+     */
+    protected function phpunitArguments($options)
+    {
+        return parent::phpunitArguments($this->filterCustomOption($options));
+    }
+
+    /**
+     * Get the array of arguments for running Paratest.
+     *
+     * @param array $options
+     *
+     * @return array
+     */
+    protected function paratestArguments($options)
+    {
+        return parent::paratestArguments($this->filterCustomOption($options));
+    }
+
+    /**
+     * Filters my custom argument from options list.
+     *
+     * @param array $options
+     *
+     * @return array
+     */
+    protected function filterCustomOption($options)
+    {
+        return array_values(array_filter($options, function ($option) {
+            return !Str::startsWith($option, '-c')
+                && !Str::startsWith($option, '--custom-argument');
+        }));
     }
 }

--- a/tests/LaravelApp/app/Console/Commands/TestCommand.php
+++ b/tests/LaravelApp/app/Console/Commands/TestCommand.php
@@ -18,7 +18,7 @@ class TestCommand extends BaseTestCommand
     {--without-tty : Disable output to TTY}
     {--p|parallel : Indicates if the tests should run in parallel}
     {--recreate-databases : Indicates if the test databases should be re-created}
-    {--c|custom-argument : Add custom env variable}
+    {--c|custom-argument : Add custom env variables}
 ';
 
     /**

--- a/tests/LaravelApp/tests/Feature/EnvironmentCustomVariablesTest.php
+++ b/tests/LaravelApp/tests/Feature/EnvironmentCustomVariablesTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+/**
+ * @group environmentCustomVariables
+ */
+class EnvironmentCustomVariablesTest extends TestCase
+{
+    /**
+     * @group environmentNoCVPhpunit
+     */
+    public function testEnvironmentNoCustomVariablesPhpunit()
+    {
+        $this->assertEquals(null, env('LARAVEL_PARALLEL_TESTING'));
+        $this->assertEquals(null, env('LARAVEL_PARALLEL_TESTING_RECREATE_DATABASES'));
+        $this->assertEquals(null, env('CUSTOM_ENV_VARIABLE'));
+        $this->assertEquals(null, env('CUSTOM_ENV_VARIABLE_FOR_PHPUNIT'));
+        $this->assertEquals(null, env('CUSTOM_ENV_VARIABLE_FOR_PARALLEL'));
+    }
+
+    /**
+     * @group environmentNoCVParallel
+     */
+    public function testEnvironmentNoCustomVariablesParallel()
+    {
+        $this->assertEquals(1, env('LARAVEL_PARALLEL_TESTING'));
+        $this->assertEquals(null, env('LARAVEL_PARALLEL_TESTING_RECREATE_DATABASES'));
+        $this->assertEquals(null, env('CUSTOM_ENV_VARIABLE'));
+        $this->assertEquals(null, env('CUSTOM_ENV_VARIABLE_FOR_PHPUNIT'));
+        $this->assertEquals(null, env('CUSTOM_ENV_VARIABLE_FOR_PARALLEL'));
+    }
+
+    /**
+     * @group environmentNoCVParallelRecreate
+     */
+    public function testEnvironmentNoCustomVariablesParallelWithRecreate()
+    {
+        $this->assertEquals(1, env('LARAVEL_PARALLEL_TESTING'));
+        $this->assertEquals(1, env('LARAVEL_PARALLEL_TESTING_RECREATE_DATABASES'));
+        $this->assertEquals(null, env('CUSTOM_ENV_VARIABLE'));
+        $this->assertEquals(null, env('CUSTOM_ENV_VARIABLE_FOR_PHPUNIT'));
+        $this->assertEquals(null, env('CUSTOM_ENV_VARIABLE_FOR_PARALLEL'));
+    }
+
+    /**
+     * @group environmentCVPhpunit
+     */
+    public function testEnvironmentCustomVariablesPhpunit()
+    {
+        $this->assertEquals(null, env('LARAVEL_PARALLEL_TESTING'));
+        $this->assertEquals(null, env('LARAVEL_PARALLEL_TESTING_RECREATE_DATABASES'));
+        $this->assertEquals(1, env('CUSTOM_ENV_VARIABLE'));
+        $this->assertEquals(1, env('CUSTOM_ENV_VARIABLE_FOR_PHPUNIT'));
+        $this->assertEquals(null, env('CUSTOM_ENV_VARIABLE_FOR_PARALLEL'));
+    }
+
+    /**
+     * @group environmentCVParallel
+     */
+    public function testEnvironmentCustomVariablesParallel()
+    {
+        $this->assertEquals(1, env('LARAVEL_PARALLEL_TESTING'));
+        $this->assertEquals(null, env('LARAVEL_PARALLEL_TESTING_RECREATE_DATABASES'));
+        $this->assertEquals(1, env('CUSTOM_ENV_VARIABLE'));
+        $this->assertEquals(null, env('CUSTOM_ENV_VARIABLE_FOR_PHPUNIT'));
+        $this->assertEquals(1, env('CUSTOM_ENV_VARIABLE_FOR_PARALLEL'));
+    }
+
+    /**
+     * @group environmentCVParallelRecreate
+     */
+    public function testEnvironmentCustomVariablesParallelWithRecreate()
+    {
+        $this->assertEquals(1, env('LARAVEL_PARALLEL_TESTING'));
+        $this->assertEquals(1, env('LARAVEL_PARALLEL_TESTING_RECREATE_DATABASES'));
+        $this->assertEquals(1, env('CUSTOM_ENV_VARIABLE'));
+        $this->assertEquals(null, env('CUSTOM_ENV_VARIABLE_FOR_PHPUNIT'));
+        $this->assertEquals(1, env('CUSTOM_ENV_VARIABLE_FOR_PARALLEL'));
+    }
+}

--- a/tests/Unit/Adapters/ArtisanTestCommandTest.php
+++ b/tests/Unit/Adapters/ArtisanTestCommandTest.php
@@ -56,6 +56,33 @@ EOF
         @unlink(__DIR__ . '/../../../tests/LaravelApp/.env.testing');
     }
 
+    /** @test */
+    public function testExtendableCustomVariables(): void
+    {
+        $this->runTests([
+            './vendor/bin/phpunit',
+            '-c',
+            'tests/LaravelApp/phpunit.xml',
+            '--group',
+            'environmentNoCVPhpunit',
+        ]);
+
+        // Without Custom Variables (-c|--custom-argument)
+        $this->runTests(['./tests/LaravelApp/artisan', 'test', '--group', 'environmentNoCVPhpunit']);
+        $this->runTests(['./tests/LaravelApp/artisan', 'test', '--parallel', '--group', 'environmentNoCVParallel']);
+        $this->runTests(['./tests/LaravelApp/artisan', 'test', '--parallel', '--recreate-databases', '--group', 'environmentNoCVParallelRecreate']);
+
+        // With Custom Variables (-c)
+        $this->runTests(['./tests/LaravelApp/artisan', 'test', '-c', '--group', 'environmentCVPhpunit']);
+        $this->runTests(['./tests/LaravelApp/artisan', 'test', '-c', '--parallel', '--group', 'environmentCVParallel']);
+        $this->runTests(['./tests/LaravelApp/artisan', 'test', '-c', '--parallel', '--recreate-databases', '--group', 'environmentCVParallelRecreate']);
+
+        // With Custom Variables (--custom-argument)
+        $this->runTests(['./tests/LaravelApp/artisan', 'test', '--custom-argument', '--group', 'environmentCVPhpunit']);
+        $this->runTests(['./tests/LaravelApp/artisan', 'test', '--custom-argument', '--parallel', '--group', 'environmentCVParallel']);
+        $this->runTests(['./tests/LaravelApp/artisan', 'test', '--custom-argument', '--parallel', '--recreate-databases', '--group', 'environmentCVParallelRecreate']);
+    }
+
     private function runTests(array $arguments): void
     {
         $process = new Process($arguments, __DIR__ . '/../../..');

--- a/tests/Unit/Adapters/PhpunitTest.php
+++ b/tests/Unit/Adapters/PhpunitTest.php
@@ -67,7 +67,7 @@ class PhpunitTest extends TestCase
     {
         $output = $this->runCollisionTests([
             '--exclude-group',
-            'fail,environmentTesting,custom-name',
+            'fail,environmentTesting,environmentCustomVariables,custom-name',
         ]);
 
         $testsDir = dirname(__DIR__, 2);
@@ -111,7 +111,7 @@ EOF,
     {
         $output = $this->runCollisionTests([
             '--exclude-group',
-            'fail,environmentTesting',
+            'fail,environmentTesting,environmentCustomVariables',
         ]);
 
         $this->assertConsoleOutputContainsString(


### PR DESCRIPTION
Hi!

Right now it's not possible to add or modify Environment Variables if you extend `Adapters\Laravel\Commands\TestCommand`.

This PR should make you able to extend TestCommand in Laravel projects to allow the possibility to inject Environment Variables, for example when you add custom arguments to artisan test

Example of extended TestCommand:

```php
namespace App\Console\Commands;

use Illuminate\Support\Str;
use NunoMaduro\Collision\Adapters\Laravel\Commands\TestCommand as BaseTestCommand;

class TestCommand extends BaseTestCommand
{
    /**
     * The name and signature of the console command.
     *
     * @var string
     */
    protected $signature = 'test
    {--without-tty : Disable output to TTY}
    {--p|parallel : Indicates if the tests should run in parallel}
    {--recreate-databases : Indicates if the test databases should be re-created}
    {--c|custom-argument : Add custom env variables}
';

    /**
     * Get the array of environment variables for running PHPUnit.
     *
     * @return array
     */
    protected function phpunitEnvironmentVariables()
    {
        if ($this->option("custom-argument")) {
            return array_merge(
                parent::phpunitEnvironmentVariables(),
                [
                    'CUSTOM_ENV_VARIABLE'                => 1,
                    'CUSTOM_ENV_VARIABLE_FOR_PHPUNIT'    => 1,
                ],
            );
        }

        return parent::phpunitEnvironmentVariables();
    }

    /**
     * Get the array of environment variables for running Paratest.
     *
     * @return array
     */
    protected function paratestEnvironmentVariables()
    {
        if ($this->option("custom-argument")) {
            return array_merge(
                parent::paratestEnvironmentVariables(),
                [
                    'CUSTOM_ENV_VARIABLE'                => 1,
                    'CUSTOM_ENV_VARIABLE_FOR_PARALLEL'   => 1,
                ],
            );
        }

        return parent::paratestEnvironmentVariables();
    }

    /**
     * Get the array of arguments for running PHPUnit.
     *
     * @param array $options
     *
     * @return array
     */
    protected function phpunitArguments($options)
    {
        return parent::phpunitArguments($this->filterCustomOption($options));
    }

    /**
     * Get the array of arguments for running Paratest.
     *
     * @param array $options
     *
     * @return array
     */
    protected function paratestArguments($options)
    {
        return parent::paratestArguments($this->filterCustomOption($options));
    }

    /**
     * Filters my custom argument from options list.
     *
     * @param array $options
     *
     * @return array
     */
    protected function filterCustomOption($options)
    {
        return array_values(array_filter($options, function ($option) {
            return !Str::startsWith($option, '-c')
                && !Str::startsWith($option, '--custom-argument');
        }));
    }
}

```