### PR TITLE
Allow symfony/console 6 as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^7.3 || ^8.0",
         "facade/ignition-contracts": "^1.0",
         "filp/whoops": "^2.14.3",
-        "symfony/console": "^5.0"
+        "symfony/console": "^5.0 || ^6.0"
     },
     "require-dev": {
         "brianium/paratest": "^6.1",


### PR DESCRIPTION
Ran tests on PHP 8.0, no issues.