### PR TITLE
Adds `--coverage` option to Artisan `test` command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         php-version: ${{ matrix.php }}
         tools: composer
-        coverage: none
+        coverage: xdebug
 
     - name: Setup Problem Matchers
       run: |

--- a/.temp/.gitkeep
+++ b/.temp/.gitkeep
@@ -1,0 +1,1 @@
+.gitkeep

--- a/src/Adapters/Laravel/Commands/TestCommand.php
+++ b/src/Adapters/Laravel/Commands/TestCommand.php
@@ -10,6 +10,7 @@ use Dotenv\Store\StoreBuilder;
 use Illuminate\Console\Command;
 use Illuminate\Support\Env;
 use Illuminate\Support\Str;
+use NunoMaduro\Collision\Coverage;
 use NunoMaduro\Collision\Adapters\Laravel\Exceptions\RequirementsException;
 use RuntimeException;
 use Symfony\Component\Process\Exception\ProcessSignaledException;
@@ -29,6 +30,8 @@ class TestCommand extends Command
      */
     protected $signature = 'test
         {--without-tty : Disable output to TTY}
+        {--coverage : Indicates whether the coverage information should be collected}
+        {--min= : Indicates the minimum threshold enforcement for coverage}
         {--p|parallel : Indicates if the tests should run in parallel}
         {--recreate-databases : Indicates if the test databases should be re-created}
     ';
@@ -68,6 +71,20 @@ class TestCommand extends Command
             throw new RequirementsException('Running Collision ^5.0 artisan test command requires at least Laravel ^8.0.');
         }
 
+        if ($this->option('coverage') && ! Coverage::isAvailable()) {
+            $this->output->writeln(sprintf(
+                "\n  <fg=white;bg=red;options=bold> ERROR </> Code coverage driver not available.%s</>",
+                Coverage::usingXdebug()
+                    ? " Did you set <href=https://xdebug.org/docs/code_coverage#mode>Xdebug's coverage mode</>?"
+                    : ''
+            ));
+
+            $this->newLine();
+
+            return 1;
+        }
+
+
         if ($this->option('parallel') && !$this->isParallelDependenciesInstalled()) {
             if (!$this->confirm('Running tests in parallel requires "brianium/paratest". Do you wish to install it as a dev dependency?')) {
                 return 1;
@@ -99,8 +116,10 @@ class TestCommand extends Command
             $this->output->writeln('Warning: ' . $e->getMessage());
         }
 
+        $exitCode = 1;
+
         try {
-            return $process->run(function ($type, $line) {
+            $exitCode = $process->run(function ($type, $line) {
                 $this->output->write($line);
             });
         } catch (ProcessSignaledException $e) {
@@ -108,6 +127,29 @@ class TestCommand extends Command
                 throw $e;
             }
         }
+
+        if ($exitCode === 0 && $this->option('coverage')) {
+
+            if (! $this->usingPest() && $this->option('parallel')) {
+                $this->newLine();
+            }
+
+            $coverage = Coverage::report($this->output);
+
+            $exitCode = (int) ($coverage < $this->option('min'));
+
+            if ($exitCode === 1) {
+                $this->output->writeln(sprintf(
+                    "\n  <fg=white;bg=red;options=bold> FAIL </> Code coverage below expected:<fg=red;options=bold> %s %%</>. Minimum:<fg=white;options=bold> %s %%</>.",
+                    number_format($coverage, 1),
+                    number_format((float) $this->option('min'), 1)
+                ));
+            }
+        }
+
+        $this->newLine();
+
+        return $exitCode;
     }
 
     /**
@@ -117,7 +159,7 @@ class TestCommand extends Command
      */
     protected function binary()
     {
-        if (class_exists(\Pest\Laravel\PestServiceProvider::class)) {
+        if ($this->usingPest()) {
             $command = $this->option('parallel') ? ['vendor/pestphp/pest/bin/pest', '--parallel'] : ['vendor/pestphp/pest/bin/pest'];
         } else {
             $command = $this->option('parallel') ? ['vendor/brianium/paratest/bin/paratest'] : ['vendor/phpunit/phpunit/phpunit'];
@@ -128,6 +170,33 @@ class TestCommand extends Command
         }
 
         return array_merge([PHP_BINARY], $command);
+    }
+
+    /**
+     * Gets the common arguments of PHPUnit and Pest.
+     *
+     * @return array
+     */
+    protected function commonArguments()
+    {
+        $arguments = [];
+
+        if ($this->option('coverage')) {
+            $arguments[] = '--coverage-php';
+            $arguments[] = Coverage::getPath();
+        }
+
+        return $arguments;
+    }
+
+    /**
+     * Determines if Pest is being used.
+     *
+     * @return bool
+     */
+    protected function usingPest()
+    {
+        return class_exists(\Pest\Laravel\PestServiceProvider::class);
     }
 
     /**
@@ -142,14 +211,16 @@ class TestCommand extends Command
         $options = array_merge(['--printer=NunoMaduro\\Collision\\Adapters\\Phpunit\\Printer'], $options);
 
         $options = array_values(array_filter($options, function ($option) {
-            return !Str::startsWith($option, '--env=');
+            return !Str::startsWith($option, '--env=')
+                && $option != '--coverage'
+                && !Str::startsWith($option, '--min');
         }));
 
         if (!file_exists($file = base_path('phpunit.xml'))) {
             $file = base_path('phpunit.xml.dist');
         }
 
-        return array_merge(["--configuration=$file"], $options);
+        return array_merge($this->commonArguments(), ["--configuration=$file"], $options);
     }
 
     /**
@@ -163,6 +234,8 @@ class TestCommand extends Command
     {
         $options = array_values(array_filter($options, function ($option) {
             return !Str::startsWith($option, '--env=')
+                && $option != '--coverage'
+                && !Str::startsWith($option, '--min')
                 && !Str::startsWith($option, '-p')
                 && !Str::startsWith($option, '--parallel')
                 && !Str::startsWith($option, '--recreate-databases');
@@ -172,7 +245,7 @@ class TestCommand extends Command
             $file = base_path('phpunit.xml.dist');
         }
 
-        return array_merge([
+        return array_merge($this->commonArguments(), [
             "--configuration=$file",
             "--runner=\Illuminate\Testing\ParallelRunner",
         ], $options);

--- a/src/Adapters/Laravel/Commands/TestCommand.php
+++ b/src/Adapters/Laravel/Commands/TestCommand.php
@@ -30,8 +30,8 @@ class TestCommand extends Command
      */
     protected $signature = 'test
         {--without-tty : Disable output to TTY}
-        {--coverage : Indicates whether the coverage information should be collected}
-        {--min= : Indicates the minimum threshold enforcement for coverage}
+        {--coverage : Indicates whether code coverage information should be collected}
+        {--min= : Indicates the minimum threshold enforcement for code coverage}
         {--p|parallel : Indicates if the tests should run in parallel}
         {--recreate-databases : Indicates if the test databases should be re-created}
     ';

--- a/src/Coverage.php
+++ b/src/Coverage.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\Collision;
+
+use SebastianBergmann\CodeCoverage\CodeCoverage;
+use SebastianBergmann\CodeCoverage\Node\Directory;
+use SebastianBergmann\CodeCoverage\Node\File;
+use SebastianBergmann\Environment\Runtime;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Terminal;
+
+/**
+ * @internal
+ */
+final class Coverage
+{
+    /**
+     * Returns the coverage path.
+     */
+    public static function getPath(): string
+    {
+        return implode(DIRECTORY_SEPARATOR, [
+            dirname(__DIR__),
+            '.temp',
+            'coverage',
+        ]);
+    }
+
+    /**
+     * Runs true there is any code coverage driver available.
+     */
+    public static function isAvailable(): bool
+    {
+        if (! (new Runtime())->canCollectCodeCoverage()) {
+            return false;
+        }
+
+        if (static::usingXdebug()) {
+            $mode = getenv('XDEBUG_MODE') ?: ini_get('xdebug.mode');
+
+            return $mode && in_array('coverage', explode(',', $mode), true);
+        }
+
+        return true;
+    }
+
+    /**
+     * If the user is using Xdebug.
+     */
+    public static function usingXdebug(): bool
+    {
+        return (new Runtime())->hasXdebug();
+    }
+
+    /**
+     * Reports the code coverage report to the
+     * console and returns the result in float.
+     */
+    public static function report(OutputInterface $output): float
+    {
+        if (!file_exists($reportPath = self::getPath())) {
+            if (self::usingXdebug()) {
+                $output->writeln(
+                    "  <fg=black;bg=yellow;options=bold> WARN </> Unable to get coverage using Xdebug. Did you set <href=https://xdebug.org/docs/code_coverage#mode>Xdebug's coverage mode</>?</>",
+                );
+
+                return 0.0;
+            }
+
+            $output->writeln(
+                "  <fg=black;bg=yellow;options=bold> WARN </> No coverage driver detected.</>",
+            );
+
+            return 0.0;
+        }
+
+        /** @var CodeCoverage $codeCoverage */
+        $codeCoverage = require $reportPath;
+        unlink($reportPath);
+
+
+        $totalCoverage = $codeCoverage->getReport()->percentageOfExecutedLines();
+
+        $totalWidth = (new Terminal())->getWidth();
+
+        $dottedLineLength = $totalWidth;
+
+        /** @var Directory<File|Directory> $report */
+        $report = $codeCoverage->getReport();
+
+        foreach ($report->getIterator() as $file) {
+            if (!$file instanceof File) {
+                continue;
+            }
+            $dirname  = dirname($file->id());
+            $basename = basename($file->id(), '.php');
+
+            $name = $dirname === '.' ? $basename : implode(DIRECTORY_SEPARATOR, [
+                $dirname,
+                $basename,
+            ]);
+            $rawName = $dirname === '.' ? $basename : implode(DIRECTORY_SEPARATOR, [
+                $dirname,
+                $basename,
+            ]);
+
+            $linesExecutedTakenSize = 0;
+
+            if ($file->percentageOfExecutedLines()->asString() != '0.00%') {
+                $linesExecutedTakenSize = strlen($uncoveredLines = trim(implode(', ', self::getMissingCoverage($file)))) + 1;
+                $name .= sprintf(' <fg=red>%s</>', $uncoveredLines);
+            }
+
+            $percentage = $file->numberOfExecutableLines() === 0
+                ? '100.0'
+                : number_format($file->percentageOfExecutedLines()->asFloat(), 1, '.', '');
+
+            $takenSize = strlen($rawName . $percentage) + 8 + $linesExecutedTakenSize; // adding 3 space and percent sign
+
+            $percentage = sprintf(
+                '<fg=%s%s>%s</>',
+                $percentage === '100.0' ? 'green' : ($percentage === '0.0' ? 'red' : 'yellow'),
+                $percentage === '100.0' ? ';options=bold' : '',
+                $percentage
+            );
+
+            $output->writeln(sprintf(
+                '  <fg=white>%s</> <fg=#6C7280>%s</> %s <fg=#6C7280>%%</>',
+                $name,
+                str_repeat('.', max($dottedLineLength - $takenSize, 1)),
+                $percentage
+            ));
+        }
+
+        $output->writeln('');
+
+        $rawName = 'Total Coverage';
+
+        $takenSize = strlen($rawName . $totalCoverage->asString()) + 6;
+
+        $output->writeln(sprintf(
+            '  <fg=white;options=bold>%s</> <fg=#6C7280>%s</> %s <fg=#6C7280>%%</>',
+            $rawName,
+            str_repeat('.', max($dottedLineLength - $takenSize, 1)),
+            number_format($totalCoverage->asFloat(), 1, '.', '')
+        ));
+
+        return $totalCoverage->asFloat();
+    }
+
+    /**
+     * Generates an array of missing coverage on the following format:.
+     *
+     * ```
+     * ['11', '20..25', '50', '60..80'];
+     * ```
+     *
+     * @param File $file
+     *
+     * @return array<int, string>
+     */
+    public static function getMissingCoverage($file): array
+    {
+        $shouldBeNewLine = true;
+
+        $eachLine = function (array $array, array $tests, int $line) use (&$shouldBeNewLine): array {
+            if (count($tests) > 0) {
+                $shouldBeNewLine = true;
+
+                return $array;
+            }
+
+            if ($shouldBeNewLine) {
+                $array[]         = (string) $line;
+                $shouldBeNewLine = false;
+
+                return $array;
+            }
+
+            $lastKey = count($array) - 1;
+
+            if (array_key_exists($lastKey, $array) && str_contains($array[$lastKey], '..')) {
+                [$from]          = explode('..', $array[$lastKey]);
+                $array[$lastKey] = $line > $from ? sprintf('%s..%s', $from, $line) : sprintf('%s..%s', $line, $from);
+
+                return $array;
+            }
+
+            $array[$lastKey] = sprintf('%s..%s', $array[$lastKey], $line);
+
+            return $array;
+        };
+
+        $array = [];
+        foreach (array_filter($file->lineCoverageData(), 'is_array') as $line => $tests) {
+            $array = $eachLine($array, $tests, $line);
+        }
+
+        return $array;
+    }
+}

--- a/tests/LaravelApp/.gitignore
+++ b/tests/LaravelApp/.gitignore
@@ -3,6 +3,7 @@
 /public/storage
 /storage/*.key
 /vendor
+.temp/coverage
 .env.backup
 .phpunit.result.cache
 Homestead.json

--- a/tests/LaravelApp/app/Console/Commands/TestCommand.php
+++ b/tests/LaravelApp/app/Console/Commands/TestCommand.php
@@ -16,6 +16,8 @@ class TestCommand extends BaseTestCommand
      */
     protected $signature = 'test
         {--without-tty : Disable output to TTY}
+        {--coverage : Indicates whether the coverage information should be collected}
+        {--min= : Indicates the minimum threshold enforcement for coverage}
         {--p|parallel : Indicates if the tests should run in parallel}
         {--recreate-databases : Indicates if the test databases should be re-created}
         {--c|custom-argument : Add custom env variables}
@@ -28,17 +30,7 @@ class TestCommand extends BaseTestCommand
      */
     protected function binary()
     {
-        switch (true) {
-            case $this->option('parallel'):
-                $command = 'vendor/brianium/paratest/bin/paratest';
-                break;
-            case class_exists(\Pest\Laravel\PestServiceProvider::class):
-                $command = 'vendor/pestphp/pest/bin/pest';
-                break;
-            default:
-                $command = 'vendor/phpunit/phpunit/phpunit';
-                break;
-        }
+        [$_, $command] = parent::binary();
 
         if ('phpdbg' === PHP_SAPI) {
             return [PHP_BINARY, '-qrr', __DIR__ . '/../../../../../' . $command];

--- a/tests/LaravelApp/app/Models/User.php
+++ b/tests/LaravelApp/app/Models/User.php
@@ -8,11 +8,10 @@ use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
-use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
-    use HasApiTokens, HasFactory, Notifiable;
+    use HasFactory, Notifiable;
 
     /**
      * The attributes that are mass assignable.

--- a/tests/LaravelApp/phpunit.xml
+++ b/tests/LaravelApp/phpunit.xml
@@ -6,9 +6,9 @@
          cacheResult="false"
          colors="true"
          convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    processIsolation="false"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
          stopOnFailure="false">
     <testsuites>
         <testsuite name="Unit">

--- a/tests/LaravelApp/tests/Feature/CoverageTest.php
+++ b/tests/LaravelApp/tests/Feature/CoverageTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+/**
+ * @group coverage
+ */
+class CoverageTest extends TestCase
+{
+    public function testExample()
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Unit/Adapters/PhpunitTest.php
+++ b/tests/Unit/Adapters/PhpunitTest.php
@@ -80,7 +80,7 @@ class PhpunitTest extends TestCase
   ! warn example → This is a warning description
   ✓ pass example
 
-  Tests:  1 warnings, 1 risky, 1 incompleted, 1 skipped, 5 passed
+  Tests:  1 warnings, 1 risky, 1 incompleted, 1 skipped, 6 passed
   Time:
 EOF,
             $output
@@ -115,7 +115,7 @@ EOF,
         ]);
 
         $this->assertConsoleOutputContainsString(
-            'Tests:  1 warnings, 1 risky, 1 incompleted, 1 skipped, 6 passed',
+            'Tests:  1 warnings, 1 risky, 1 incompleted, 1 skipped, 7 passed',
             $output
         );
     }

--- a/tests/Unit/CoverageTest.php
+++ b/tests/Unit/CoverageTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use NunoMaduro\Collision\Coverage;
+use PHPUnit\Framework\TestCase;
+
+class CoverageTest extends TestCase
+{
+    /** @test */
+    public function testGetPath(): void
+    {
+        $this->assertSame(dirname(__DIR__, 2) . '/' . '.temp/coverage', Coverage::getPath());
+    }
+
+    /** @test */
+    public function testIsAvailable(): void
+    {
+        $this->assertTrue(Coverage::isAvailable());
+    }
+
+    /** @test */
+    public function testUsingXdebug(): void
+    {
+        $this->assertTrue(Coverage::usingXdebug());
+    }
+}


### PR DESCRIPTION
This pull request introduces `--coverage` option to Artisan `test` command.

<img width="1172" alt="Screenshot 2022-01-19 at 12 44 48" src="https://user-images.githubusercontent.com/5457236/150133237-440290c2-3538-4d8e-8eac-4fdd5ec7bd9e.png">

## No driver available 

Using coverage in PHP requires Xdebug or equivalent coverage driver. If no driver available, this gets displayed:

<img width="763" alt="Screenshot 2022-01-18 at 17 35 26" src="https://user-images.githubusercontent.com/5457236/149989591-e755bd79-775a-45e4-a6f4-27f44f8a0b4e.png">

If Debug is installed, but the XDEBUG_MODE does not contain `coverage` this gets displayed:

<img width="859" alt="Screenshot 2022-01-18 at 17 36 26" src="https://user-images.githubusercontent.com/5457236/149989677-a89a5614-20f5-446f-836c-39bff8da0f00.png">

## The `--min` option

This pull request's code also may gets used in CIs to ensure a specific coverage threshold:

<img width="941" alt="Screenshot 2022-01-18 at 17 38 07" src="https://user-images.githubusercontent.com/5457236/149989794-06d587c9-4728-4665-a3b6-c3354a454baa.png">

If the coverage threshold is not respected, this gets displayed and the status code is 1:

<img width="941" alt="Screenshot 2022-01-18 at 17 38 14" src="https://user-images.githubusercontent.com/5457236/149989853-a29a7629-2bfa-4bf3-bbf7-cdba339ec157.png">