### PR TITLE
Add prophecy to ignore files in writeError

### DIFF
--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -180,6 +180,7 @@ final class Style
         $writer->ignoreFilesIn([
             '/vendor\/pestphp\/pest/',
             '/vendor\/phpspec\/prophecy-phpunit/',
+            '/vendor\/phpspec\/prophecy/',
             '/vendor\/phpunit\/phpunit\/src/',
             '/vendor\/mockery\/mockery/',
             '/vendor\/laravel\/dusk/',


### PR DESCRIPTION


**Before**


<img width="574" alt="Bildschirmfoto 2022-01-28 um 18 05 37" src="https://user-images.githubusercontent.com/1698337/151590697-90bc0c0c-41a9-4447-8e75-7406343a6c70.png">


**After**

<img width="932" alt="Bildschirmfoto 2022-01-28 um 18 05 45" src="https://user-images.githubusercontent.com/1698337/151590744-838b275e-e7c2-4f55-acd9-4d2a59f8041c.png">

Not sure if 5.x is still supported by I'm still on symfony 5.
