### PR TITLE
Minimize phpunit output w/o --verbose flag

### DIFF
--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\ExceptionWrapper;
 use PHPUnit\Framework\ExpectationFailedException;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 use Whoops\Exception\Inspector;
 
@@ -69,6 +70,10 @@ final class Style
         }
 
         $state->eachTestCaseTests(function (TestResult $testResult) {
+            if ($testResult->type === 'passed' && $this->output->getVerbosity() < OutputInterface::VERBOSITY_VERBOSE) {
+                return;
+            }
+
             $this->output->writeln($this->testLineFrom(
                 $testResult->color,
                 $testResult->icon,


### PR DESCRIPTION
This is sort of a continuation of https://github.com/pestphp/pest/issues/95. In that issue, the `--compact` option was suggested but later it was implied that perhaps compact be default and we can show the expanded output when `--verbose` is used.

Output example _without_ `--verbose`:

```
   FAIL  Tests\Unit\Adapters\PhpunitTest
  ⨯ it has tests
  ⨯ it has custom test case name
  ⨯ it has recap
  ⨯ it informs the user when no tests are executed
  ⨯ it has failure
  ⨯ it has output in stdout with be strict about output during tests false

   PASS  Tests\Unit\ArgumentFormatterTest

   PASS  Tests\Unit\CoverageTest

   PASS  Tests\Unit\HandlerTest

   PASS  Tests\Unit\ProviderTest

   PASS  Tests\Unit\WriterTest
```

Output example _with_ `--verbose`:

```
   FAIL  Tests\Unit\Adapters\PhpunitTest
  ✓ it respects is contract
  ✓ it is a printer
  ✓ it do not handles test that are not test cases
  ⨯ it has tests
  ⨯ it has custom test case name
  ⨯ it has recap
  ⨯ it informs the user when no tests are executed
  ⨯ it has failure
  ✓ it has output in stdout with be strict about output during tests false

   PASS  Tests\Unit\ArgumentFormatterTest
  ✓ it respects is contract
  ✓ it formats a string
  ✓ it formats a long string
  ✓ it formats a array
  ✓ it formats a object

   PASS  Tests\Unit\CoverageTest
  ✓ get path
  ✓ is available
  ✓ using xdebug

   PASS  Tests\Unit\HandlerTest
  ✓ it respects is contract
  ✓ it handles an exception
  ✓ it sets the output
  ✓ it gets the writer

   PASS  Tests\Unit\ProviderTest
  ✓ it respects is contract
  ✓ it registers the error handler
  ✓ it gets the handler

   PASS  Tests\Unit\WriterTest
  ✓ it respects is contract
  ✓ it gets the output
  ✓ it sets the output
  ✓ it writes the exception
  ✓ it writes details
  ✓ it ignores folders
  ✓ it hides editor
  ✓ it hides trace
  ✓ it supports renderless contracts
```

I was thinking that we could put the # of passed tests (if possible) in the summary if not using `--verbose`:

```
   PASS  Tests\Unit\ArgumentFormatterTest (5 tests)
```

I had a bit of trouble getting the test suite passing locally. If this is of interest, I will fix up the tests.