### PR TITLE
Add webmozart/assert library to ignoreFiles of stacktrace

### DIFF
--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -196,6 +196,7 @@ final class Style
             '/bin\/phpunit/',
             '/vendor\/coduo\/php-matcher\/src\/PHPUnit/',
             '/vendor\/sulu\/sulu\/src\/Sulu\/Bundle\/TestBundle\/Testing/',
+            '/vendor\/webmozart\/assert/',
         ]);
 
         if ($throwable instanceof ExceptionWrapper && $throwable->getOriginalException() !== null) {


### PR DESCRIPTION
Before:


<img width="633" alt="Bildschirmfoto 2022-02-09 um 14 37 02" src="https://user-images.githubusercontent.com/1698337/153212572-13f20622-f6f8-4c60-ab63-a0943a35e296.png">

After:

<img width="652" alt="Bildschirmfoto 2022-02-09 um 14 37 11" src="https://user-images.githubusercontent.com/1698337/153212561-69f1ca18-2a1e-43ad-a4a2-5e595d96f5b5.png">

Sometimes I'm thinking in which cases we want to show a the line from `vendor` directory? And maybe the whole `vendor` should just be excluded.
