### PR TITLE
Add drop databases flag for parity with laravel

### DIFF
--- a/src/Adapters/Laravel/Commands/TestCommand.php
+++ b/src/Adapters/Laravel/Commands/TestCommand.php
@@ -34,6 +34,7 @@ class TestCommand extends Command
         {--min= : Indicates the minimum threshold enforcement for code coverage}
         {--p|parallel : Indicates if the tests should run in parallel}
         {--recreate-databases : Indicates if the test databases should be re-created}
+        {--drop-databases : Indicates if the test databases should be dropped}
     ';
 
     /**
@@ -238,7 +239,8 @@ class TestCommand extends Command
                 && !Str::startsWith($option, '--min')
                 && !Str::startsWith($option, '-p')
                 && !Str::startsWith($option, '--parallel')
-                && !Str::startsWith($option, '--recreate-databases');
+                && !Str::startsWith($option, '--recreate-databases')
+                && !Str::startsWith($option, '--drop-databases');
         }));
 
         if (!file_exists($file = base_path('phpunit.xml'))) {
@@ -271,6 +273,7 @@ class TestCommand extends Command
         return [
             'LARAVEL_PARALLEL_TESTING'                    => 1,
             'LARAVEL_PARALLEL_TESTING_RECREATE_DATABASES' => $this->option('recreate-databases'),
+            'LARAVEL_PARALLEL_TESTING_DROP_DATABASES' => $this->option('drop-databases'),
         ];
     }
 

--- a/tests/LaravelApp/app/Console/Commands/TestCommand.php
+++ b/tests/LaravelApp/app/Console/Commands/TestCommand.php
@@ -20,6 +20,7 @@ class TestCommand extends BaseTestCommand
         {--min= : Indicates the minimum threshold enforcement for coverage}
         {--p|parallel : Indicates if the tests should run in parallel}
         {--recreate-databases : Indicates if the test databases should be re-created}
+        {--drop-databases : Indicates if the test databases should be dropped}
         {--c|custom-argument : Add custom env variables}
 ';
 

--- a/tests/Unit/Adapters/ArtisanTestCommandTest.php
+++ b/tests/Unit/Adapters/ArtisanTestCommandTest.php
@@ -61,6 +61,7 @@ class ArtisanTestCommandTest extends TestCase
         $this->runTests(['./tests/LaravelApp/artisan', 'test', '--group', 'environment']);
         $this->runTests(['./tests/LaravelApp/artisan', 'test', '--parallel', '--group', 'environment']);
         $this->runTests(['./tests/LaravelApp/artisan', 'test', '--parallel', '--recreate-databases', '--group', 'environment']);
+        $this->runTests(['./tests/LaravelApp/artisan', 'test', '--parallel', '--drop-databases', '--group', 'environment']);
     }
 
     /** @test */
@@ -83,6 +84,7 @@ EOF
         $this->runTests(['./tests/LaravelApp/artisan', 'test', '--group', 'environmentTesting']);
         $this->runTests(['./tests/LaravelApp/artisan', 'test', '--parallel', '--group', 'environmentTesting']);
         $this->runTests(['./tests/LaravelApp/artisan', 'test', '--parallel', '--recreate-databases', '--group', 'environmentTesting']);
+        $this->runTests(['./tests/LaravelApp/artisan', 'test', '--parallel', '--drop-databases', '--group', 'environmentTesting']);
     }
 
     /**
@@ -108,16 +110,19 @@ EOF
         $this->runTests(['./tests/LaravelApp/artisan', 'test', '--group', 'environmentNoCVPhpunit']);
         $this->runTests(['./tests/LaravelApp/artisan', 'test', '--parallel', '--group', 'environmentNoCVParallel']);
         $this->runTests(['./tests/LaravelApp/artisan', 'test', '--parallel', '--recreate-databases', '--group', 'environmentNoCVParallelRecreate']);
+        $this->runTests(['./tests/LaravelApp/artisan', 'test', '--parallel', '--drop-databases', '--group', 'environmentNoCVParallelRecreate']);
 
         // With Custom Variables (-c)
         $this->runTests(['./tests/LaravelApp/artisan', 'test', '-c', '--group', 'environmentCVPhpunit']);
         $this->runTests(['./tests/LaravelApp/artisan', 'test', '-c', '--parallel', '--group', 'environmentCVParallel']);
         $this->runTests(['./tests/LaravelApp/artisan', 'test', '-c', '--parallel', '--recreate-databases', '--group', 'environmentCVParallelRecreate']);
+        $this->runTests(['./tests/LaravelApp/artisan', 'test', '-c', '--parallel', '--drop-databases', '--group', 'environmentCVParallelRecreate']);
 
         // With Custom Variables (--custom-argument)
         $this->runTests(['./tests/LaravelApp/artisan', 'test', '--custom-argument', '--group', 'environmentCVPhpunit']);
         $this->runTests(['./tests/LaravelApp/artisan', 'test', '--custom-argument', '--parallel', '--group', 'environmentCVParallel']);
         $this->runTests(['./tests/LaravelApp/artisan', 'test', '--custom-argument', '--parallel', '--recreate-databases', '--group', 'environmentCVParallelRecreate']);
+        $this->runTests(['./tests/LaravelApp/artisan', 'test', '--custom-argument', '--parallel', '--drop-databases', '--group', 'environmentCVParallelRecreate']);
     }
 
     private function runTests(array $arguments, int $expectedExitCode = 0): string


### PR DESCRIPTION
Laravel added the ability to drop databases in parallel tests in laravel/framework#41806, this PR adds this feature to collision also. 