### PR TITLE
Fix problem with "static" workflow not using prefer-lowest

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -23,7 +23,7 @@ jobs:
         coverage: none
 
     - name: Install Dependencies
-      run: composer update --prefer-stable --no-interaction --prefer-dist --no-progress --ansi
+      run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist --no-progress --ansi
 
     - name: Run PHPStan
       run: vendor/bin/phpstan analyse --no-progress --ansi


### PR DESCRIPTION
`static` workflow defines `dependency-version` in `matrix`, but does not use `matrix.dependency-version` internally.

Therefore, even the job `PHPStan prefer-lowest` is executed with `--prefer-stable`, as shown in the image below.
https://github.com/nunomaduro/collision/runs/5836478682?check_suite_focus=true
<img width="761" alt="スクリーンショット 2022-04-18 22 36 53" src="https://user-images.githubusercontent.com/5019072/163816269-96304160-0acb-4ef7-b09f-bc382536963b.png">



I changed the code to use `matrix.dependency-version` as in `tests` workflow.

Now it will run with `--prefer-lowest`. Test also succeeded.
https://github.com/yamadashy/collision/runs/6063154359?check_suite_focus=true
<img width="755" alt="スクリーンショット 2022-04-18 22 49 37" src="https://user-images.githubusercontent.com/5019072/163817953-851efd9a-ac28-4240-90fb-96ae87a789b3.png">