### PR TITLE
Add multiline support for warnings

### DIFF
--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -264,11 +264,9 @@ final class Style
                 foreach($warningLines as $w) {
                     $warning .= sprintf(
                         "\n  → %s",
-                        $w
+                        trim($w)
                     );
                 }
-
-                $warning .= "\n";
             }
         }
 

--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -252,7 +252,7 @@ final class Style
     {
         if (! empty($warning)) {
 
-            if (! str_contains("warning", "\n")) {
+            if (! str_contains($warning, "\n")) {
                 $warning = sprintf(
                     ' → %s',
                     $warning

--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -251,10 +251,25 @@ final class Style
     private function testLineFrom(string $fg, string $icon, string $description, string $warning = null): string
     {
         if (! empty($warning)) {
-            $warning = sprintf(
-                ' → %s',
-                $warning
-            );
+
+            if (! str_contains("warning", "\n")) {
+                $warning = sprintf(
+                    ' → %s',
+                    $warning
+                );
+            } else {
+                $warningLines = explode("\n", $warning);
+                $warning = '';
+
+                foreach($warningLines as $w) {
+                    $warning .= sprintf(
+                        "\n  → %s",
+                        $w
+                    );
+                }
+
+                $warning .= "\n";
+            }
         }
 
         return sprintf(

--- a/src/Adapters/Phpunit/TestResult.php
+++ b/src/Adapters/Phpunit/TestResult.php
@@ -77,6 +77,13 @@ final class TestResult
     public $warning = '';
 
     /**
+     * Define how Warnings and Errors are printed with newline characters.
+     *
+     * @var bool
+     */
+    public static bool $allowMultiline = false;
+
+    /**
      * Test constructor.
      */
     private function __construct(string $testCaseName, string $description, string $type, string $icon, string $color, Throwable $throwable = null)
@@ -94,7 +101,12 @@ final class TestResult
              || $this->type === TestResult::INCOMPLETE;
 
         if ($throwable instanceof Throwable && $asWarning) {
-            $this->warning = trim((string) preg_replace("/\r|\n/", ' ', $throwable->getMessage()));
+
+            if(static::$allowMultiline) {
+                $this->warning = trim((string) $throwable->getMessage());
+            } else {
+                $this->warning = trim((string) preg_replace("/\r|\n/", ' ', $throwable->getMessage()));
+            }
         }
     }
 


### PR DESCRIPTION
If you have multiple independending warnings per Test case, then I think it would be great, if these are printed in multiple lines, instead of being separated by a single space.

I added an opt-in option for this behaviour.
(it would also be possible to always print the warnings in a new line, which I think would be even better)

Here a demo repo for testing the changes:
https://github.com/Jubeki/nunomaduro-collision-demo

Before or without opt-in:
<img width="1007" alt="Screenshot 2022-07-13 at 13 47 05" src="https://user-images.githubusercontent.com/15707543/178726997-afcb141b-f22c-482c-9532-3063bc27227d.png">

After (opted-in):
<img width="1007" alt="Screenshot 2022-07-13 at 13 46 41" src="https://user-images.githubusercontent.com/15707543/178727038-bb2feeda-bbc5-431c-877f-652402f1eabf.png">

