### PR TITLE
add clearified message in case xdebug and pcov are not installed

### DIFF
--- a/src/Adapters/Laravel/Commands/TestCommand.php
+++ b/src/Adapters/Laravel/Commands/TestCommand.php
@@ -77,7 +77,7 @@ class TestCommand extends Command
                 "\n  <fg=white;bg=red;options=bold> ERROR </> Code coverage driver not available.%s</>",
                 Coverage::usingXdebug()
                     ? " Did you set <href=https://xdebug.org/docs/code_coverage#mode>Xdebug's coverage mode</>?"
-                    : " Did you install <href=https://xdebug.org/>Xdebug</> or <href=https://pecl.php.net/package/pcov>PCOV</>?"
+                    : " Did you install <href=https://xdebug.org/>Xdebug</> or <href=https://github.com/krakjoe/pcov>PCOV</>?"
             ));
 
             $this->newLine();

--- a/src/Adapters/Laravel/Commands/TestCommand.php
+++ b/src/Adapters/Laravel/Commands/TestCommand.php
@@ -77,7 +77,7 @@ class TestCommand extends Command
                 "\n  <fg=white;bg=red;options=bold> ERROR </> Code coverage driver not available.%s</>",
                 Coverage::usingXdebug()
                     ? " Did you set <href=https://xdebug.org/docs/code_coverage#mode>Xdebug's coverage mode</>?"
-                    : ''
+                    : " Did you install <href=https://xdebug.org/>Xdebug</> or <href=https://pecl.php.net/package/pcov>PCOV</>?"
             ));
 
             $this->newLine();

--- a/src/Coverage.php
+++ b/src/Coverage.php
@@ -70,7 +70,7 @@ final class Coverage
             }
 
             $output->writeln(
-                '  <fg=black;bg=yellow;options=bold> WARN </> No coverage driver detected.</> Did you install <href=https://xdebug.org/>Xdebug</> or <href=https://pecl.php.net/package/pcov>PCOV</>?',
+                '  <fg=black;bg=yellow;options=bold> WARN </> No coverage driver detected.</> Did you install <href=https://xdebug.org/>Xdebug</> or <href=https://github.com/krakjoe/pcov>PCOV</>?',
             );
 
             return 0.0;

--- a/src/Coverage.php
+++ b/src/Coverage.php
@@ -70,7 +70,7 @@ final class Coverage
             }
 
             $output->writeln(
-                '  <fg=black;bg=yellow;options=bold> WARN </> No coverage driver detected.</>',
+                '  <fg=black;bg=yellow;options=bold> WARN </> No coverage driver detected.</> Did you install <href=https://xdebug.org/>Xdebug</> or <href=https://pecl.php.net/package/pcov>PCOV</>?',
             );
 
             return 0.0;


### PR DESCRIPTION
Hi,

I just migrated a project of mine to Laravel 9 and I got a little confused due to error messages during migration. I think this clearification could help some users.