### PR TITLE
Add support with --without-databases to laravel test command

### DIFF
--- a/src/Adapters/Laravel/Commands/TestCommand.php
+++ b/src/Adapters/Laravel/Commands/TestCommand.php
@@ -35,6 +35,7 @@ class TestCommand extends Command
         {--p|parallel : Indicates if the tests should run in parallel}
         {--recreate-databases : Indicates if the test databases should be re-created}
         {--drop-databases : Indicates if the test databases should be dropped}
+        {--without-databases : Indicates if database configuration should be performed}
     ';
 
     /**
@@ -240,7 +241,8 @@ class TestCommand extends Command
                 && ! Str::startsWith($option, '-p')
                 && ! Str::startsWith($option, '--parallel')
                 && ! Str::startsWith($option, '--recreate-databases')
-                && ! Str::startsWith($option, '--drop-databases');
+                && ! Str::startsWith($option, '--drop-databases')
+                && ! Str::startsWith($option, '--without-databases');
         }));
 
         if (! file_exists($file = base_path('phpunit.xml'))) {
@@ -274,6 +276,7 @@ class TestCommand extends Command
             'LARAVEL_PARALLEL_TESTING' => 1,
             'LARAVEL_PARALLEL_TESTING_RECREATE_DATABASES' => $this->option('recreate-databases'),
             'LARAVEL_PARALLEL_TESTING_DROP_DATABASES' => $this->option('drop-databases'),
+            'LARAVEL_PARALLEL_TESTING_WITHOUT_DATABASES' => $this->option('without-databases'),
         ];
     }
 


### PR DESCRIPTION
Currently Laravel has an option for parallel testing `--without-databases` that skips database configuration [(see here)](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Testing/Concerns/TestDatabases.php#L48). This PR adds support for that option