### PR TITLE
enable --no-ansi to work

### DIFF
--- a/src/Adapters/Laravel/Commands/TestCommand.php
+++ b/src/Adapters/Laravel/Commands/TestCommand.php
@@ -208,9 +208,10 @@ class TestCommand extends Command
     {
         $options = array_merge(['--printer=NunoMaduro\\Collision\\Adapters\\Phpunit\\Printer'], $options);
 
-	// convert artisan color option to what phpunit expects
+        // convert artisan color option to what phpunit expects
         $options = array_map(function ($option) {
             $option = $option == '--no-ansi' ? '--color=never' : $option;
+
             return $option;
         }, $options);
 

--- a/src/Adapters/Laravel/Commands/TestCommand.php
+++ b/src/Adapters/Laravel/Commands/TestCommand.php
@@ -208,6 +208,12 @@ class TestCommand extends Command
     {
         $options = array_merge(['--printer=NunoMaduro\\Collision\\Adapters\\Phpunit\\Printer'], $options);
 
+	// convert artisan color option to what phpunit expects
+        $options = array_map(function ($option) {
+            $option = $option == '--no-ansi' ? '--color=never' : $option;
+            return $option;
+        }, $options);
+
         $options = array_values(array_filter($options, function ($option) {
             return ! Str::startsWith($option, '--env=')
                 && $option != '-q'


### PR DESCRIPTION
Before this

```
./artisan test --no-ansi
PHPUnit 9.5.26 by Sebastian Bergmann and contributors.

Unknown option "--no-ansi"
```

But with this change I get uncolored output when wanted

I have only tested by using this in my local Laravel project - but it works OK there  

NB` ./artisan test --help`

suggests 

`      --ansi|--no-ansi      Force (or disable --no-ansi) ANSI output`
