### PR TITLE
Fix bug when calling tests with `--ansi` and `--no-ansi` parameters

### DIFF
--- a/src/Adapters/Laravel/Commands/TestCommand.php
+++ b/src/Adapters/Laravel/Commands/TestCommand.php
@@ -196,6 +196,16 @@ class TestCommand extends Command
             $arguments[] = Coverage::getPath();
         }
 
+        if ($this->option('ansi')) {
+            $arguments[] = '--colors';
+            $arguments[] = 'always';
+        }
+
+        if ($this->option('no-ansi')) {
+            $arguments[] = '--colors';
+            $arguments[] = 'never';
+        }
+
         return $arguments;
     }
 
@@ -226,6 +236,8 @@ class TestCommand extends Command
                 && $option != '--coverage'
                 && $option != '--compact'
                 && $option != '--profile'
+                && $option != '--ansi'
+                && $option != '--no-ansi'
                 && ! Str::startsWith($option, '--min');
         }));
 
@@ -249,6 +261,8 @@ class TestCommand extends Command
                 && $option != '--coverage'
                 && $option != '-q'
                 && $option != '--quiet'
+                && $option != '--ansi'
+                && $option != '--no-ansi'
                 && ! Str::startsWith($option, '--min')
                 && ! Str::startsWith($option, '-p')
                 && ! Str::startsWith($option, '--parallel')

--- a/tests/Unit/Adapters/ArtisanTestCommandTest.php
+++ b/tests/Unit/Adapters/ArtisanTestCommandTest.php
@@ -50,6 +50,13 @@ class ArtisanTestCommandTest extends TestCase
     }
 
     /** @test */
+    public function testAnsi(): void
+    {
+        $this->runTests(['./tests/LaravelApp/artisan', 'test', '--ansi']);
+        $this->runTests(['./tests/LaravelApp/artisan', 'test', '--no-ansi']);
+    }
+
+    /** @test */
     public function testEnv(): void
     {
         $this->runTests([


### PR DESCRIPTION
Fix for https://github.com/laravel/framework/issues/45340

![image](https://user-images.githubusercontent.com/10347617/208742637-0b079875-b23f-4d60-9405-d72849c19859.png)

![image](https://user-images.githubusercontent.com/10347617/208742694-01ea671e-b558-4ec3-b726-920d122b2506.png)

![image](https://user-images.githubusercontent.com/10347617/208742753-9c605538-bfea-425b-a9ce-342c0ef6d352.png)
