### PR TITLE
Fix Coverage::isAvailable for case with both pcov and xdebug enabled

### DIFF
--- a/src/Coverage.php
+++ b/src/Coverage.php
@@ -33,8 +33,14 @@ final class Coverage
      */
     public static function isAvailable(): bool
     {
-        if (! (new Runtime())->canCollectCodeCoverage()) {
+        $runtime = new Runtime();
+
+        if (! $runtime->canCollectCodeCoverage()) {
             return false;
+        }
+
+        if ($runtime->hasPCOV() || $runtime->hasPHPDBGCodeCoverage()) {
+            return true;
         }
 
         if (static::usingXdebug()) {


### PR DESCRIPTION
It's possible when both xdebug and pcov extensions are enabled, but for different purposes: xdebug for debugging only, pcov for coverage. In such configuration `ini_get('xdebug.mode')` will not include `coverage` and thus pcov should be prioritised when running `Coverage::isAvailable()`