### PR TITLE
[7.x] Style `code blocks` on test descriptions.

### DIFF
--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -419,6 +419,8 @@ final class Style
             $warning = sprintf('<span class="ml-1 text-yellow">%s</span>', $warning);
         }
 
+        $description = preg_replace('/`([^`]+)`/', '<span class="text-white">$1</span>', $result->description);
+
         renderUsing($this->output);
         render(sprintf(<<<'HTML'
             <div class="%s ml-2">
@@ -426,6 +428,6 @@ final class Style
                     <span class="text-%s font-bold">%s</span><span class="ml-1 text-gray">%s</span>%s
                 </span>%s
             </div>
-        HTML, $seconds === '' ? '' : 'flex space-x-1 justify-between', $truncateClasses, $result->color, $result->icon, $result->description, $warning, $seconds));
+        HTML, $seconds === '' ? '' : 'flex space-x-1 justify-between', $truncateClasses, $result->color, $result->icon, $description, $warning, $seconds));
     }
 }


### PR DESCRIPTION
This PR transforms this:

<img width="1014" alt="image" src="https://user-images.githubusercontent.com/823088/211009018-086fb802-bc59-45ba-90b1-371e106fac29.png">

to this:

<img width="966" alt="image" src="https://user-images.githubusercontent.com/823088/211008924-783da611-e730-458e-a004-592508b8012d.png">
