### PR TITLE
[Pest adapter] Exclude Pest custom expectation code from failure snippets

### DIFF
--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -8,6 +8,7 @@ use NunoMaduro\Collision\Adapters\Phpunit\Printers\DefaultPrinter;
 use NunoMaduro\Collision\Exceptions\ShouldNotHappen;
 use NunoMaduro\Collision\Exceptions\TestException;
 use NunoMaduro\Collision\Writer;
+use Pest\Expectation;
 use PHPUnit\Event\Code\Throwable;
 use PHPUnit\Event\Telemetry\Info;
 use PHPUnit\Framework\ExpectationFailedException;
@@ -333,6 +334,13 @@ final class Style
             '/vendor\/sulu\/sulu\/src\/Sulu\/Bundle\/TestBundle\/Testing/',
             '/vendor\/webmozart\/assert/',
         ]);
+
+        if (class_exists(Expectation::class)) {
+            $reflection = new ReflectionClass(Expectation::class);
+
+            /** @phpstan-ignore-next-line  */
+            $writer->ignoreClosuresIn($reflection->getStaticPropertyValue('extends', []));
+        }
 
         /** @var \Throwable $throwable */
         $inspector = new Inspector($throwable);

--- a/tests/Unit/WriterTest.php
+++ b/tests/Unit/WriterTest.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Tests\FakeProgram\HelloWorldFile1;
 use Tests\FakeProgram\HelloWorldFile4;
+use Whoops\Exception\Frame;
 use Whoops\Exception\Inspector;
 
 class WriterTest extends TestCase
@@ -111,6 +112,33 @@ EOF;
 EOF;
 
         $this->assertStringContainsString($result, $writer->getOutput()->fetch());
+    }
+
+    /** @test */
+    public function itIgnoresClosures(): void
+    {
+        $inspector = new Inspector(HelloWorldFile1::say());
+
+        ($writer = $this->createWriter())->ignoreFilesIn([function (Frame $frame) {
+            return str_contains($frame->getFile(), 'FakeProgram');
+        }])
+            ->write($inspector);
+
+        $space = ' ';
+
+        $result = <<<EOF
+
+   Tests\FakeProgram\FakeException$space
+
+  Fail description
+
+  at tests/Unit/WriterTest.php
+EOF;
+
+        $this->assertStringContainsString(
+            $result,
+            $writer->getOutput()->fetch()
+        );
     }
 
     /** @test */


### PR DESCRIPTION
This PR will help showing the right code snippet when a Pest custom expectation fails.

A quick solution would be to just ignore `tests/Pest.php` file, but this won't solve the issue when expectations are extended inside external packages or different files. This fix uses reflections to detect the lines where expectation extension happened and skips their snippets frames.

before: 

![image](https://user-images.githubusercontent.com/8792274/219875692-09dac6da-343e-4e91-88f0-1578b593dd5c.png)

after:

![image](https://user-images.githubusercontent.com/8792274/219875707-15dcfc37-83fb-4ed0-8328-621ff4db9f2e.png)
