### PR TITLE
Exclude Pest expectation pipes code from failure snippets

### DIFF
--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NunoMaduro\Collision\Adapters\Phpunit;
 
+use Closure;
 use NunoMaduro\Collision\Adapters\Phpunit\Printers\DefaultPrinter;
 use NunoMaduro\Collision\Exceptions\ShouldNotHappen;
 use NunoMaduro\Collision\Exceptions\TestException;
@@ -480,7 +481,7 @@ final class Style
     /**
      * @param  Frame  $frame
      */
-    private function isFrameInClosure($frame, \Closure $closure): bool
+    private function isFrameInClosure($frame, Closure $closure): bool
     {
         $reflection = new ReflectionFunction($closure);
 


### PR DESCRIPTION
This will extend #254 by excluding also pipe code snippets from failures

**note**

this works for pipes, but there is still an issue for pest `->intercept` calls, as the actual interceptor is wrapped inside a closure before being converted into a pipe

in order to detect if the snippet belongs to an interceptor, we need to extract its handler closure using ReflectionFunction::getClosureUsedVariables() (as interceptors are wrapped into a pipe and its handler is `use`d in the pipe closure.

this is not currently possible as there is a bug in PHP 8.2/8.1 that prevents reflection to retrieve used variables when a closure has variadic arguments (see https://github.com/php/php-src/issues/10623)

I implemented a workaround in Pest, by storing also interceptor closures in order to be retrieved in Collision. Will implement the workaround as soon as [this](https://github.com/pestphp/pest/pull/668) is merged in Pest core

