### PR TITLE
Exclude Pest expectation interceptors code from failure snippets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
             "email": "enunomaduro@gmail.com"
         }
     ],
+    "version": "7.x-dev",
     "require": {
         "php": "^8.1.0",
         "filp/whoops": "^2.14.6",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
             "email": "enunomaduro@gmail.com"
         }
     ],
-    "version": "7.x-dev",
     "require": {
         "php": "^8.1.0",
         "filp/whoops": "^2.14.6",

--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -340,6 +340,7 @@ final class Style
 
             $this->ignorePestPipes(...),
             $this->ignorePestExtends(...),
+            $this->ignorePestInterceptors(...),
         ]);
 
         /** @var \Throwable $throwable */
@@ -475,6 +476,29 @@ final class Style
             foreach ($extends as $extendClosure) {
                 if ($this->isFrameInClosure($frame, $extendClosure)) {
                     return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  Frame  $frame
+     */
+    private function ignorePestInterceptors($frame): bool
+    {
+        if (class_exists(Expectation::class)) {
+            $reflection = new ReflectionClass(Expectation::class);
+
+            /** @var array<string, array<Closure(Closure, mixed ...$arguments): void>> $expectationInterceptors */
+            $expectationInterceptors = $reflection->getStaticPropertyValue('interceptors', []);
+
+            foreach ($expectationInterceptors as $pipes) {
+                foreach ($pipes as $pipeClosure) {
+                    if ($this->isFrameInClosure($frame, $pipeClosure)) {
+                        return true;
+                    }
                 }
             }
         }

--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -341,6 +341,7 @@ final class Style
             $this->ignorePestPipes(...),
             $this->ignorePestExtends(...),
             $this->ignorePestInterceptors(...),
+
         ]);
 
         /** @var \Throwable $throwable */


### PR DESCRIPTION
this PR is a workaround for excluding Pest interceptors code from error snippets, it follows #254 and #255 

as soon as PHP 8.1/8.2 bug https://github.com/php/php-src/issues/10623#issuecomment-1436023780 will be fixed (current fix PR: https://github.com/php/php-src/pull/10625), this workaround will be updated as follows:

- this Pest PR will be reverted: https://github.com/pestphp/pest/pull/668#event-8555597818
- `$this->ignorePestInterceptors(...)` will not be needed anymore
- `ignorePestPipes()` will be updated for using `ReflectionFunction` to retrieve interceptor lines from its wrapper pipe, this way:

```diff
private function ignorePestPipes($frame): bool
{
    if (class_exists(Expectation::class)) {
        $reflection = new ReflectionClass(Expectation::class);

        /** @var array<string, array<Closure(Closure, mixed ...$arguments): void>> $expectationPipes */
        $expectationPipes = $reflection->getStaticPropertyValue('pipes', []);

        foreach ($expectationPipes as $pipes) {
            foreach ($pipes as $pipeClosure) {
                
+               $pipeReflection = new ReflectionFunction($pipeClosure);
+               $pipeUses = $pipeReflection->getClosureUsedVariables();
+               if(array_key_exists('$handler', $pipeUses)){
+                   $pipeClosure = $pipeUses['$handler'];
+               }
                
                if ($this->isFrameInClosure($frame, $pipeClosure)) {
                    return true;
                }
            }
        }
    }

    return false;
}
