### PR TITLE
Implements Exception CustomEditor

### DIFF
--- a/src/Concerns/RendersCustomEditor.php
+++ b/src/Concerns/RendersCustomEditor.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace NunoMaduro\Collision\Concerns;
+
+use Whoops\Exception\Frame;
+
+trait RendersCustomEditor
+{
+    private string $customEditorFile;
+
+    private int $customEditorLine;
+
+    public function getCustomEditorFrame(): Frame|null
+    {
+        if (! isset($this->customEditorFile)) {
+            return null;
+        }
+
+        return new Frame([
+            'file' => $this->customEditorFile,
+            'line' => $this->customEditorLine,
+        ]);
+    }
+
+    public function withCustomEditor(string $file, int $line): static
+    {
+        $this->customEditorFile = $file;
+        $this->customEditorLine = $line;
+
+        return $this;
+    }
+}

--- a/src/Contracts/CustomEditor.php
+++ b/src/Contracts/CustomEditor.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace NunoMaduro\Collision\Contracts;
+
+use Whoops\Exception\Frame;
+
+interface CustomEditor
+{
+    public function getCustomEditorFrame(): Frame|null;
+}

--- a/src/Coverage.php
+++ b/src/Coverage.php
@@ -45,7 +45,7 @@ final class Coverage
             return true;
         }
 
-        if (static::usingXdebug()) {
+        if (self::usingXdebug()) {
             $mode = getenv('XDEBUG_MODE') ?: ini_get('xdebug.mode');
 
             return $mode && in_array('coverage', explode(',', $mode), true);

--- a/src/Exceptions/TestException.php
+++ b/src/Exceptions/TestException.php
@@ -25,6 +25,11 @@ final class TestException
         //
     }
 
+    public function getThrowable(): Throwable
+    {
+        return $this->throwable;
+    }
+
     /**
      * @return class-string
      */

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NunoMaduro\Collision;
 
 use Closure;
+use NunoMaduro\Collision\Contracts\CustomEditor;
 use NunoMaduro\Collision\Contracts\RenderlessEditor;
 use NunoMaduro\Collision\Contracts\RenderlessTrace;
 use NunoMaduro\Collision\Contracts\SolutionsRepository;
@@ -92,7 +93,13 @@ final class Writer
 
         $frames = $this->getFrames($inspector);
 
-        $editorFrame = array_shift($frames);
+        $exception = $inspector->getException();
+
+        if ($exception instanceof CustomEditor && $exception->getCustomEditorFrame()) {
+            $editorFrame = $exception->getCustomEditorFrame();
+        } else {
+            $editorFrame = array_shift($frames);
+        }
 
         $exception = $inspector->getException();
 

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -95,13 +95,13 @@ final class Writer
 
         $exception = $inspector->getException();
 
-        if ($exception instanceof CustomEditor && $exception->getCustomEditorFrame()) {
-            $editorFrame = $exception->getCustomEditorFrame();
+        $realException = $exception instanceof TestException ? $exception->getThrowable() : $exception;
+
+        if ($realException instanceof CustomEditor && $realException->getCustomEditorFrame()) {
+            $editorFrame = $realException->getCustomEditorFrame();
         } else {
             $editorFrame = array_shift($frames);
         }
-
-        $exception = $inspector->getException();
 
         if ($this->showEditor
             && $editorFrame !== null

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -95,10 +95,8 @@ final class Writer
 
         $exception = $inspector->getException();
 
-        $realException = $exception instanceof TestException ? $exception->getThrowable() : $exception;
-
-        if ($realException instanceof CustomEditor && $realException->getCustomEditorFrame()) {
-            $editorFrame = $realException->getCustomEditorFrame();
+        if ($exception instanceof CustomEditor && $exception->getCustomEditorFrame()) {
+            $editorFrame = $exception->getCustomEditorFrame();
         } else {
             $editorFrame = array_shift($frames);
         }

--- a/tests/FakeProgram/FakeCustomEditorException.php
+++ b/tests/FakeProgram/FakeCustomEditorException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FakeProgram;
+
+use Exception;
+use NunoMaduro\Collision\Concerns\RendersCustomEditor;
+use NunoMaduro\Collision\Contracts\CustomEditor;
+
+class FakeCustomEditorException extends Exception implements CustomEditor
+{
+    use RendersCustomEditor;
+
+    public static function make(string $message): FakeCustomEditorException
+    {
+        return new self($message);
+    }
+}

--- a/tests/FakeProgram/HelloWorldFile5.php
+++ b/tests/FakeProgram/HelloWorldFile5.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FakeProgram;
+
+class HelloWorldFile5
+{
+    public static function say(): FakeCustomEditorException
+    {
+        return (new FakeCustomEditorException('Fail custom editor description'))
+            ->withCustomEditor(__DIR__.'/FakeCustomEditorException.php', 15);
+    }
+}

--- a/tests/Unit/WriterTest.php
+++ b/tests/Unit/WriterTest.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Tests\FakeProgram\HelloWorldFile1;
 use Tests\FakeProgram\HelloWorldFile4;
+use Tests\FakeProgram\HelloWorldFile5;
 use Whoops\Exception\Frame;
 use Whoops\Exception\Inspector;
 
@@ -243,6 +244,46 @@ EOF;
 
    Tests\FakeProgram\FakeRenderlessException \n
   Fail renderless description\n
+EOF;
+
+        $this->assertEquals(
+            $writer->getOutput()
+                ->fetch(),
+            $result
+        );
+    }
+
+    /** @test  */
+    public function itSupportsCustomEditorContracts(): void
+    {
+        $inspector = new Inspector(HelloWorldFile5::say());
+
+        ($writer = $this->createWriter())->write($inspector);
+        $space = ' ';
+        $result = <<<EOF
+
+   Tests\FakeProgram\FakeCustomEditorException$space
+
+  Fail custom editor description
+
+  at tests/FakeProgram/FakeCustomEditorException.php:15
+     11▕ use NunoMaduro\Collision\Contracts\RenderlessTrace;
+     12▕$space
+     13▕ class FakeCustomEditorException extends Exception implements CustomEditor
+     14▕ {
+  ➜  15▕     use RendersCustomEditor;
+     16▕$space
+     17▕     public static function make(string \$message): FakeCustomEditorException
+     18▕     {
+     19▕         return new self(\$message);
+
+  1   tests/FakeProgram/HelloWorldFile5.php:11
+      Tests\FakeProgram\FakeCustomEditorException::("Fail custom editor description")
+
+  2   tests/Unit/WriterTest.php:259
+      Tests\FakeProgram\HelloWorldFile5::say()
+
+
 EOF;
 
         $this->assertEquals(


### PR DESCRIPTION
This PR will add a CustomEditor interface that allows exceptions to define path and line for the code snippet to show in collision rendered editor:

Let's assume (I'm really doing it, a PR will be opened after this will be merged) that in Pest Arch plugin we want to throw a failure when a violation occurs like this one:

![image](https://user-images.githubusercontent.com/8792274/227593726-e98e15c2-3bec-4824-aeba-0d302634f382.png)

All is great, but the snippet points out to the test code, not the actual code that violated the rule

we have the path and the line where the violation occurred (see the failure message), but it would be great to throw this 

![image](https://user-images.githubusercontent.com/8792274/227603858-318d96c0-7220-4c72-ac3a-a3b9491e88d4.png)
