### PR TITLE
Add: shorten `not contain` error messages too

### DIFF
--- a/tests/Unit/TestExceptionTest.php
+++ b/tests/Unit/TestExceptionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use NunoMaduro\Collision\Exceptions\TestException;
+use PHPUnit\Event\Code\Throwable;
+use PHPUnit\Framework\TestCase;
+
+class TestExceptionTest extends TestCase
+{
+    /** @test */
+    public function itShortensContainsErrorMessages(): void
+    {
+        $message = <<<'EOF'
+  Failed asserting that 'aaa
+bbb
+ccc
+ddd
+eee
+fff' does not contain "Pest".
+EOF;
+
+        $expect = <<<'EOF'
+Expected: aaa
+  bbb
+  ccc
+  ... (3 more lines)
+
+  Not to contain: Pest
+EOF;
+
+        $testException = new TestException(new Throwable(self::class, $message, 'description', '', null), false);
+
+        $this->assertStringContainsString($expect, strip_tags($testException->getMessage()));
+    }
+
+    /** @test */
+    public function itShortensNotContainErrorMessages(): void
+    {
+        $message = <<<'EOF'
+  Failed asserting that 'aaa
+bbb
+ccc
+ddd
+eee
+fff' contains "Pest".
+EOF;
+
+        $expect = <<<'EOF'
+Expected: aaa
+  bbb
+  ccc
+  ... (3 more lines)
+
+  To contain: Pest
+EOF;
+
+        $testException = new TestException(new Throwable(self::class, $message, 'description', '', null), false);
+
+        $this->assertStringContainsString($expect, strip_tags($testException->getMessage()));
+    }
+}


### PR DESCRIPTION
This PR shortens 'not contain' error messages too.
It is really good for readability.

### Before:
![2023-04-11_22h27_31](https://user-images.githubusercontent.com/14008307/231178778-63418bb2-f6b3-425d-8e89-acf9449cbdd3.png)

### After:
![2023-04-11_22h28_13](https://user-images.githubusercontent.com/14008307/231178831-79713d61-321a-45af-840b-31b28259792d.png)

I also added a small fix for counting `%s more lines`. (substracted 3)
