### PR TITLE
Remove unused findComposer method

### DIFF
--- a/src/Adapters/Laravel/Commands/TestCommand.php
+++ b/src/Adapters/Laravel/Commands/TestCommand.php
@@ -389,20 +389,4 @@ class TestCommand extends Command
     {
         return class_exists(\ParaTest\ParaTestCommand::class);
     }
-
-    /**
-     * Get the composer command for the environment.
-     *
-     * @return string
-     */
-    protected function findComposer()
-    {
-        $composerPath = getcwd().'/composer.phar';
-
-        if (file_exists($composerPath)) {
-            return '"'.PHP_BINARY.'" '.$composerPath;
-        }
-
-        return 'composer';
-    }
 }


### PR DESCRIPTION
This method was added in #168 to allow installing parallel test dependencies through the CLI, but is no longer used.