### PR TITLE
Add reportable and renderable method

### DIFF
--- a/src/Adapters/Laravel/ExceptionHandler.php
+++ b/src/Adapters/Laravel/ExceptionHandler.php
@@ -84,4 +84,26 @@ final class ExceptionHandler implements ExceptionHandlerContract
     {
         return $this->appExceptionHandler->shouldReport($e);
     }
+
+    /**
+     * Register a renderable callback.
+     *
+     * @param  callable  $renderUsing
+     * @return $this
+     */
+    public function reportable(callable $reportUsing)
+    {
+        $this->appExceptionHandler->reportable($reportUsing);
+    }
+
+    /**
+     * Register a reportable callback.
+     *
+     * @param  callable  $reportUsing
+     * @return \Illuminate\Foundation\Exceptions\ReportableHandler
+     */
+    public function renderable(callable $renderUsing)
+    {
+        $this->appExceptionHandler->renderable($renderUsing);
+    }
 }


### PR DESCRIPTION
In laravel when `Illuminate\Contracts\Debug\\ExceptionHandler` bind to `App\Exceptions\Handler::class`, develoepr can define reportable in service provider:

```php
$this->app->make(ExceptionHandler::class)->reportable(function (\Exception $e) {
});
```

but when bind to this `NunoMaduro\Collision\Adapters\Laravel\ExceptionHandler` call to undefined method exception occurs