### PR TITLE
Catch PHPUnit Errors and Deprecations

### DIFF
--- a/src/Adapters/Phpunit/Printers/DefaultPrinter.php
+++ b/src/Adapters/Phpunit/Printers/DefaultPrinter.php
@@ -25,6 +25,8 @@ use PHPUnit\Event\Test\NoticeTriggered;
 use PHPUnit\Event\Test\Passed;
 use PHPUnit\Event\Test\PhpDeprecationTriggered;
 use PHPUnit\Event\Test\PhpNoticeTriggered;
+use PHPUnit\Event\Test\PhpunitDeprecationTriggered;
+use PHPUnit\Event\Test\PhpunitErrorTriggered;
 use PHPUnit\Event\Test\PhpunitWarningTriggered;
 use PHPUnit\Event\Test\PhpWarningTriggered;
 use PHPUnit\Event\Test\PreparationStarted;
@@ -314,6 +316,26 @@ final class DefaultPrinter
         $throwable = ThrowableBuilder::from(new TestOutcome($event->message()));
 
         $this->state->add(TestResult::fromTestCase($event->test(), TestResult::DEPRECATED, $throwable));
+    }
+
+    /**
+     * Listen to the test phpunit deprecation triggered event.
+     */
+    public function testPhpunitDeprecationTriggered(PhpunitDeprecationTriggered $event): void
+    {
+        $throwable = ThrowableBuilder::from(new TestOutcome($event->message()));
+
+        $this->state->add(TestResult::fromTestCase($event->test(), TestResult::DEPRECATED, $throwable));
+    }
+
+    /**
+     * Listen to the test phpunit error triggered event.
+     */
+    public function testPhpunitErrorTriggered(PhpunitErrorTriggered $event): void
+    {
+        $throwable = ThrowableBuilder::from(new TestOutcome($event->message()));
+
+        $this->state->add(TestResult::fromTestCase($event->test(), TestResult::FAIL, $throwable));
     }
 
     /**

--- a/src/Adapters/Phpunit/Subscribers/EnsurePrinterIsRegisteredSubscriber.php
+++ b/src/Adapters/Phpunit/Subscribers/EnsurePrinterIsRegisteredSubscriber.php
@@ -31,6 +31,10 @@ use PHPUnit\Event\Test\PhpDeprecationTriggered;
 use PHPUnit\Event\Test\PhpDeprecationTriggeredSubscriber;
 use PHPUnit\Event\Test\PhpNoticeTriggered;
 use PHPUnit\Event\Test\PhpNoticeTriggeredSubscriber;
+use PHPUnit\Event\Test\PhpunitDeprecationTriggered;
+use PHPUnit\Event\Test\PhpunitDeprecationTriggeredSubscriber;
+use PHPUnit\Event\Test\PhpunitErrorTriggered;
+use PHPUnit\Event\Test\PhpunitErrorTriggeredSubscriber;
 use PHPUnit\Event\Test\PhpunitWarningTriggered;
 use PHPUnit\Event\Test\PhpunitWarningTriggeredSubscriber;
 use PHPUnit\Event\Test\PhpWarningTriggered;
@@ -189,6 +193,14 @@ if (class_exists(Version::class) && (int) Version::series() >= 10) {
                     }
                 },
 
+                new class($printer) extends Subscriber implements PhpunitDeprecationTriggeredSubscriber
+                {
+                    public function notify(PhpunitDeprecationTriggered $event): void
+                    {
+                        $this->printer()->testPhpunitDeprecationTriggered($event);
+                    }
+                },
+
                 new class($printer) extends Subscriber implements PhpNoticeTriggeredSubscriber
                 {
                     public function notify(PhpNoticeTriggered $event): void
@@ -210,6 +222,14 @@ if (class_exists(Version::class) && (int) Version::series() >= 10) {
                     public function notify(PhpunitWarningTriggered $event): void
                     {
                         $this->printer()->testPhpunitWarningTriggered($event);
+                    }
+                },
+
+                new class($printer) extends Subscriber implements PhpunitErrorTriggeredSubscriber
+                {
+                    public function notify(PhpunitErrorTriggered $event): void
+                    {
+                        $this->printer()->testPhpunitErrorTriggered($event);
                     }
                 },
 


### PR DESCRIPTION
Fixes #271 

Currently `php artisan test` doesn't display PHPUnit Errors or Deprecations, which can be quite important for seeing tests which are not running or failing due to an Error in a Data Provider for example.

This PR registeres the two additional Subscriber to listen for this events and display them in the console.

I created an example repository to show the issue:

Setting up the repository
```bash
git clone git@github.com:Jubeki/nunomaduro-collission-example.git
composer update
cp .env.example .env
php artisan key:generate
```

Output of `php artisan test` without this PR:
<img width="1697" alt="Screenshot 2023-08-03 at 10 56 59" src="https://github.com/nunomaduro/collision/assets/15707543/0f60bcd0-2057-425e-a2d0-fbdb921e659b">


Output of `vendor/bin/phpunit`:
<img width="1697" alt="Screenshot 2023-08-03 at 10 57 25" src="https://github.com/nunomaduro/collision/assets/15707543/dc3e5a2b-9cda-4378-b9d0-fdced52d6f13">


You can see that the test y is not running in `php artisan test` but you would'nt know that.
You can also not see the deprecation like with `vendor/bin/phpunit`

To see the results of this PR you can do the following:
```bash
cp composer-remote.json composer.json
composer update
```

Output of `php artisan test` with this PR:
<img width="1697" alt="Screenshot 2023-08-03 at 10 57 57" src="https://github.com/nunomaduro/collision/assets/15707543/39bc297a-4d6c-4d39-9db4-2bc3dbae1183">