### PR TITLE
Improve `TODO` readability

### DIFF
--- a/src/Adapters/Phpunit/State.php
+++ b/src/Adapters/Phpunit/State.php
@@ -158,7 +158,7 @@ final class State
     public function getTestCaseFontColor(): string
     {
         if ($this->getTestCaseTitleColor() === 'blue') {
-            return 'white';
+            return 'gray';
         }
 
         return $this->getTestCaseTitle() === 'FAIL' ? 'default' : 'black';


### PR DESCRIPTION
Personally, I find the `TODO` hard to read. This PR improves that readability.

Before:
![afbeelding](https://github.com/nunomaduro/collision/assets/11609290/096e6955-ae51-4654-9918-35aab11de083)

After:
![afbeelding](https://github.com/nunomaduro/collision/assets/11609290/89072dbb-4012-4ec2-a379-3da39e7c8471)
