### PR TITLE
Add ide links

### DIFF
--- a/src/Writer.php
+++ b/src/Writer.php
@@ -260,7 +260,8 @@ final class Writer
 
             // getLine() might return null so cast to int to get 0 instead
             $line = (int) $frame->getLine();
-            $this->render('at <fg=green>'.$file.'</>'.':<fg=green>'.$line.'</>');
+            $href = $this->getEditorLink($frame);
+            $this->render('at <fg=green;href='.$href.'>'.$file.'</>'.':<fg=green>'.$line.'</>');
 
             $content = $this->highlighter->highlight((string) $frame->getFileContents(), (int) $frame->getLine());
 
@@ -308,8 +309,9 @@ final class Writer
                 );
                 $vendorFrames = 0;
             }
+            $href = $this->getEditorLink($frame);
 
-            $this->render("<fg=yellow>$pos</><fg=default;options=bold>$file</>:<fg=default;options=bold>$line</>", (bool) $class && $i > 0);
+            $this->render("<fg=yellow>$pos</><fg=default;options=bold;href=$href>$file</>:<fg=default;options=bold>$line</>", (bool) $class && $i > 0);
             if ($class) {
                 $this->render("<fg=gray>    $class$function($args)</>", false);
             }
@@ -348,5 +350,18 @@ final class Writer
         }
 
         return $filePath;
+    }
+
+    /**
+     * Returns a phpstorm protocol link that opens the file in PhpStorm on the selected line 
+     * @param Frame $frame
+     * @return string
+     */
+    private function getEditorLink(Frame $frame): string
+    {
+        return 'phpstorm://open?' . http_build_query([
+            'file' => (string) $frame->getFile(),
+            'line' => $frame->getLine(),
+        ]);
     }
 }


### PR DESCRIPTION
I know you rejected #186 but I hope you'll consider this PR for a couple of reasons:

- This implementation is _a lot_ simpler and doesn't require any changes to php config.
- Lots of other popular packages provide ide links (e.g. ignition, laravel-debugbar and whoops) so the demand for this feature is growing.

This is just a bare minimum proof of concept to check if you're open to the idea. If you are, I'd be happy to add support for other editors, like Whoops does: https://github.com/filp/whoops/blob/c83e88a30524f9360b11f585f71e6b17313b7187/src/Whoops/Handler/PrettyPageHandler.php#L109-L125 