### PR TITLE
Do not suppress warning messages

### DIFF
--- a/src/Adapters/Phpunit/Printers/DefaultPrinter.php
+++ b/src/Adapters/Phpunit/Printers/DefaultPrinter.php
@@ -263,9 +263,7 @@ final class DefaultPrinter
      */
     public function testRunnerWarningTriggered(TestRunnerWarningTriggered $event): void
     {
-        if (! str_starts_with($event->message(), 'No tests found in class')) {
-            $this->style->writeWarning($event->message());
-        }
+        $this->style->writeWarning($event->message());
     }
 
     /**


### PR DESCRIPTION
This is a fix for #293. Warnings should not be suppressed, unless you also suppress the output on `STDERR`.