### PR TITLE
Modify regular expressions to detect error messages

### DIFF
--- a/src/Exceptions/TestException.php
+++ b/src/Exceptions/TestException.php
@@ -47,8 +47,8 @@ final class TestException
         }
 
         $regexes = [
-            'To contain' => '/Failed asserting that \'(.*)\' contains "(.*)"\./s',
-            'Not to contain' => '/Failed asserting that \'(.*)\' does not contain "(.*)"\./s',
+            'To contain' => '/Failed asserting that \'(.*)\' \[[\w-]+\]\(length: [\d]+\) contains "(.*)"/s',
+            'Not to contain' => '/Failed asserting that \'(.*)\' \[[\w-]+\]\(length: [\d]+\) does not contain "(.*)"/s',
         ];
 
         foreach ($regexes as $key => $pattern) {

--- a/tests/Unit/TestExceptionTest.php
+++ b/tests/Unit/TestExceptionTest.php
@@ -19,7 +19,7 @@ bbb
 ccc
 ddd
 eee
-fff' does not contain "Pest".
+fff' [UTF-8](length: 10248) does not contain "Pest" [UTF-8](length: 4).
 EOF;
 
         $expect = <<<'EOF'
@@ -45,7 +45,7 @@ bbb
 ccc
 ddd
 eee
-fff' contains "Pest".
+fff' [UTF-8](length: 10248) contains "Pest" [UTF-8](length: 4).
 EOF;
 
         $expect = <<<'EOF'


### PR DESCRIPTION
In PHPUnit v.10.4.0, the error message format was changed.
https://github.com/sebastianbergmann/phpunit/commit/20571aa9d174f751e74754c15e71d8d3b0b7b267

So we need to update the regular expressions used to detect error messages.