### PR TITLE
Add a tip when PHP warnings were triggered

### DIFF
--- a/src/Adapters/Phpunit/State.php
+++ b/src/Adapters/Phpunit/State.php
@@ -143,6 +143,20 @@ final class State
     }
 
     /**
+     * Check if the test case contains any test with a warning.
+     */
+    public function testCaseHasWarnings(): bool
+    {
+        foreach ($this->testCaseTests as $test) {
+            if ($test->type === TestResult::WARN) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Gets the number of tests that are todos.
      */
     public function todosCount(): int

--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -122,6 +122,18 @@ final class Style
                 }
             }
         });
+
+        $configuration = Registry::get();
+
+        if (
+            $state->testCaseHasWarnings() &&
+            ! $configuration->failOnWarning() &&
+            ! $configuration->displayDetailsOnTestsThatTriggerWarnings()
+        ) {
+            $this->output->writeln(
+                '  <fg=yellow>TIP:</> <fg=gray>use --display-warnings to print details about warnings.</>'
+            );
+        }
     }
 
     /**

--- a/tests/Unit/Adapters/PhpunitTest.php
+++ b/tests/Unit/Adapters/PhpunitTest.php
@@ -98,6 +98,77 @@ EOF,
     }
 
     #[Test]
+    public function itPrintsATipWhenItHasAPhpWarning(): void
+    {
+        $output = $this->runCollisionTests([
+            '--group',
+            'warnings',
+        ]);
+
+        $this->assertConsoleOutputContainsString(<<<'EOF'
+   WARN  Tests\Unit\ExampleTest
+  ! warning → Undefined property: Tests\Unit\ExampleTest::$blabla
+  ! user warning → This is a user warning
+  TIP: use --display-warnings to print details about warnings.
+
+  Tests:    2 warnings (2 assertions)
+  Duration
+EOF,
+            $output
+        );
+    }
+
+    #[Test]
+    public function itDoesNotPrintATipWhenItHasAPhpNoticeOrDeprecation(): void
+    {
+        $output = $this->runCollisionTests([
+            '--group',
+            'notices',
+        ]);
+
+        $this->assertConsoleOutputNotContainsString(
+            'TIP: use --display-warnings to print details about warnings.',
+            $output,
+        );
+
+        $output = $this->runCollisionTests([
+            '--group',
+            'deprecations',
+        ]);
+
+        $this->assertConsoleOutputNotContainsString(
+            'TIP: use --display-warnings to print details about warnings.',
+            $output,
+        );
+    }
+
+    #[Test]
+    public function itDoesNotPrintATipWhenTestsAreRunWithDisplayWarningsOrFailOnWarningOption(): void
+    {
+        $output = $this->runCollisionTests([
+            '--group',
+            'warnings',
+            '--display-warnings',
+        ]);
+
+        $this->assertConsoleOutputNotContainsString(
+            'TIP: use --display-warnings to print details about warnings.',
+            $output,
+        );
+
+        $output = $this->runCollisionTests([
+            '--group',
+            'warnings',
+            '--fail-on-warning',
+        ]);
+
+        $this->assertConsoleOutputNotContainsString(
+            'TIP: use --display-warnings to print details about warnings.',
+            $output,
+        );
+    }
+
+    #[Test]
     public function itHasATodo(): void
     {
         $output = $this->runCollisionTests([


### PR DESCRIPTION
When PHP warnings are triggered in a test case, the output does not show any details, like in which file the warning was triggered. Running the tests with --display-warnings gives you all the details. Add a tip for users to add the option when running the command.

Background to this PR: https://twitter.com/enunomaduro/status/1754525232075788730 

The output looks like this:
<img width="778" alt="Bildschirmfoto 2024-02-05 um 22 52 31" src="https://github.com/nunomaduro/collision/assets/4062813/dea8567a-08cf-4f46-bfbc-ca77ed9a0b37">
