### PR TITLE
Mute suppressed warnings

### DIFF
--- a/src/Adapters/Phpunit/Subscribers/EnsurePrinterIsRegisteredSubscriber.php
+++ b/src/Adapters/Phpunit/Subscribers/EnsurePrinterIsRegisteredSubscriber.php
@@ -213,7 +213,9 @@ if (class_exists(Version::class) && (int) Version::series() >= 10) {
                 {
                     public function notify(PhpWarningTriggered $event): void
                     {
-                        $this->printer()->testPhpWarningTriggered($event);
+                        if (! $event->wasSuppressed()) {
+                            $this->printer()->testPhpWarningTriggered($event);
+                        }
                     }
                 },
 


### PR DESCRIPTION
PHPUnit tracks if a warning was suppressed via the `@` operator. By default the `@` is honored and suppressed warnings are hidden from PHPUnit's default printer. Pest, however, does not honor the `@` and shows warnings regardless of the configuration.

See: https://docs.phpunit.de/en/10.5/error-handling.html#ignoring-issue-suppression

If you find this helpful I can expand this to include all warnings, notices, and errors before this is considered/merged.