### PR TITLE
Support new error solutions package

### DIFF
--- a/src/Adapters/Laravel/IgnitionSolutionsRepository.php
+++ b/src/Adapters/Laravel/IgnitionSolutionsRepository.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace NunoMaduro\Collision\Adapters\Laravel;
 
 use NunoMaduro\Collision\Contracts\SolutionsRepository;
-use Spatie\Ignition\Contracts\SolutionProviderRepository;
+use Spatie\ErrorSolutions\Contracts\SolutionProviderRepository;
+use Spatie\Ignition\Contracts\SolutionProviderRepository as IgnitionSolutionProviderRepository;
 use Throwable;
 
 /**
@@ -16,14 +17,14 @@ final class IgnitionSolutionsRepository implements SolutionsRepository
     /**
      * Holds an instance of ignition solutions provider repository.
      *
-     * @var \Spatie\Ignition\Contracts\SolutionProviderRepository
+     * @var IgnitionSolutionProviderRepository|SolutionProviderRepository
      */
     protected $solutionProviderRepository; // @phpstan-ignore-line
 
     /**
      * IgnitionSolutionsRepository constructor.
      */
-    public function __construct(SolutionProviderRepository $solutionProviderRepository) // @phpstan-ignore-line
+    public function __construct(IgnitionSolutionProviderRepository|SolutionProviderRepository $solutionProviderRepository) // @phpstan-ignore-line
     {
         $this->solutionProviderRepository = $solutionProviderRepository;
     }


### PR DESCRIPTION
This PR adds support for the new error solutions package.

This solutions package is extracted out of the old Ignition error package so we can use it in both the new Flare client package and new package to display solutions on the default Laravel error page.