### PR TITLE
Add an option that allows you to hide all files where code coverage is full in the code coverage output

### DIFF
--- a/src/Adapters/Laravel/Commands/TestCommand.php
+++ b/src/Adapters/Laravel/Commands/TestCommand.php
@@ -37,6 +37,7 @@ class TestCommand extends Command
         {--compact : Indicates whether the compact printer should be used}
         {--coverage : Indicates whether code coverage information should be collected}
         {--min= : Indicates the minimum threshold enforcement for code coverage}
+        {--hide-full-coverage : Do not report any files where code coverage is 100%}
         {--p|parallel : Indicates if the tests should run in parallel}
         {--profile : Lists top 10 slowest tests}
         {--recreate-databases : Indicates if the test databases should be re-created}
@@ -130,7 +131,8 @@ class TestCommand extends Command
                 $this->newLine();
             }
 
-            $coverage = Coverage::report($this->output);
+            $hideFullCoverage = (bool) $this->option('hide-full-coverage');
+            $coverage = Coverage::report($this->output, $hideFullCoverage);
 
             $exitCode = (int) ($coverage < $this->option('min'));
 
@@ -216,6 +218,7 @@ class TestCommand extends Command
                 && $option != '-q'
                 && $option != '--quiet'
                 && $option != '--coverage'
+                && $option != '--hide-full-coverage'
                 && $option != '--compact'
                 && $option != '--profile'
                 && $option != '--ansi'
@@ -256,6 +259,7 @@ class TestCommand extends Command
                 && $option != '--ansi'
                 && $option != '--no-ansi'
                 && ! Str::startsWith($option, '--min')
+                && ! Str::startsWith($option, '--hide-full-coverage')
                 && ! Str::startsWith($option, '-p')
                 && ! Str::startsWith($option, '--parallel')
                 && ! Str::startsWith($option, '--recreate-databases')

--- a/src/Adapters/Laravel/Commands/TestCommand.php
+++ b/src/Adapters/Laravel/Commands/TestCommand.php
@@ -37,7 +37,7 @@ class TestCommand extends Command
         {--compact : Indicates whether the compact printer should be used}
         {--coverage : Indicates whether code coverage information should be collected}
         {--min= : Indicates the minimum threshold enforcement for code coverage}
-        {--hide-full-coverage : Do not report any files where code coverage is 100%}
+        {--quiet-coverage : Do not report any files where code coverage is 100%}
         {--p|parallel : Indicates if the tests should run in parallel}
         {--profile : Lists top 10 slowest tests}
         {--recreate-databases : Indicates if the test databases should be re-created}
@@ -131,7 +131,7 @@ class TestCommand extends Command
                 $this->newLine();
             }
 
-            $hideFullCoverage = (bool) $this->option('hide-full-coverage');
+            $hideFullCoverage = (bool) $this->option('quiet-coverage');
             $coverage = Coverage::report($this->output, $hideFullCoverage);
 
             $exitCode = (int) ($coverage < $this->option('min'));
@@ -218,7 +218,7 @@ class TestCommand extends Command
                 && $option != '-q'
                 && $option != '--quiet'
                 && $option != '--coverage'
-                && $option != '--hide-full-coverage'
+                && $option != '--quiet-coverage'
                 && $option != '--compact'
                 && $option != '--profile'
                 && $option != '--ansi'
@@ -259,7 +259,7 @@ class TestCommand extends Command
                 && $option != '--ansi'
                 && $option != '--no-ansi'
                 && ! Str::startsWith($option, '--min')
-                && ! Str::startsWith($option, '--hide-full-coverage')
+                && ! Str::startsWith($option, '--quiet-coverage')
                 && ! Str::startsWith($option, '-p')
                 && ! Str::startsWith($option, '--parallel')
                 && ! Str::startsWith($option, '--recreate-databases')

--- a/src/Coverage.php
+++ b/src/Coverage.php
@@ -67,8 +67,16 @@ final class Coverage
      * Reports the code coverage report to the
      * console and returns the result in float.
      */
-    public static function report(OutputInterface $output): float
+    public static function report(OutputInterface $output, bool $hideFullCoverage): float
     {
+        $filesExcluded = $hideFullCoverage ? ' (files with full coverage not printed)' : '';
+        renderUsing($output);
+        render(<<<HTML
+            <div class="mx-2">
+                <span class="mb-1 font-bold">Code Coverage{$filesExcluded}:</span>
+            </div>
+        HTML);
+
         if (! file_exists($reportPath = self::getPath())) {
             if (self::usingXdebug()) {
                 $output->writeln(
@@ -109,6 +117,10 @@ final class Coverage
             $percentage = $file->numberOfExecutableLines() === 0
                 ? '100.0'
                 : number_format($file->percentageOfExecutedLines()->asFloat(), 1, '.', '');
+
+            if ($percentage === '100.0' && $hideFullCoverage) {
+                continue;
+            }
 
             $uncoveredLines = '';
 

--- a/src/Coverage.php
+++ b/src/Coverage.php
@@ -69,14 +69,6 @@ final class Coverage
      */
     public static function report(OutputInterface $output, bool $hideFullCoverage): float
     {
-        $filesExcluded = $hideFullCoverage ? ' (files with full coverage not printed)' : '';
-        renderUsing($output);
-        render(<<<HTML
-            <div class="mx-2">
-                <span class="mb-1 font-bold">Code Coverage{$filesExcluded}:</span>
-            </div>
-        HTML);
-
         if (! file_exists($reportPath = self::getPath())) {
             if (self::usingXdebug()) {
                 $output->writeln(

--- a/tests/LaravelApp/app/Console/Commands/TestCommand.php
+++ b/tests/LaravelApp/app/Console/Commands/TestCommand.php
@@ -19,6 +19,7 @@ class TestCommand extends BaseTestCommand
         {--compact : Indicates whether the compact printer should be used}
         {--coverage : Indicates whether code coverage information should be collected}
         {--min= : Indicates the minimum threshold enforcement for code coverage}
+        {--hide-full-coverage : Do not report any files where code coverage is 100%}
         {--p|parallel : Indicates if the tests should run in parallel}
         {--profile : Lists top 10 slowest tests}
         {--recreate-databases : Indicates if the test databases should be re-created}

--- a/tests/LaravelApp/app/Console/Commands/TestCommand.php
+++ b/tests/LaravelApp/app/Console/Commands/TestCommand.php
@@ -19,7 +19,7 @@ class TestCommand extends BaseTestCommand
         {--compact : Indicates whether the compact printer should be used}
         {--coverage : Indicates whether code coverage information should be collected}
         {--min= : Indicates the minimum threshold enforcement for code coverage}
-        {--hide-full-coverage : Do not report any files where code coverage is 100%}
+        {--quiet-coverage : Do not report any files where code coverage is 100%}
         {--p|parallel : Indicates if the tests should run in parallel}
         {--profile : Lists top 10 slowest tests}
         {--recreate-databases : Indicates if the test databases should be re-created}

--- a/tests/Unit/Adapters/ArtisanTestCommandTest.php
+++ b/tests/Unit/Adapters/ArtisanTestCommandTest.php
@@ -15,8 +15,11 @@ class ArtisanTestCommandTest extends TestCase
     public function testCoverage(): void
     {
         $output = $this->runTests(['./tests/LaravelApp/artisan', 'test', '--coverage', '--group', 'coverage']);
+        $this->assertStringContainsString('Code Coverage:', $output);
         $this->assertStringContainsString('Models/User', $output);
         $this->assertStringContainsString('0.0', $output);
+        $this->assertStringContainsString('Http/Controllers/Controller', $output);
+        $this->assertStringContainsString('100.0', $output);
         $this->assertStringContainsString('Total: ', $output);
 
         /**
@@ -48,6 +51,18 @@ class ArtisanTestCommandTest extends TestCase
         $this->assertStringContainsString('Total: ', $output);
         $this->assertStringContainsString('Code coverage below expected', $output);
         */
+    }
+
+    #[Test]
+    public function testHideFullCoverage(): void
+    {
+        $output = $this->runTests(['./tests/LaravelApp/artisan', 'test', '--coverage', '--hide-full-coverage', '--group', 'coverage'], 0);
+        $this->assertStringContainsString('Code Coverage (files with full coverage not printed):', $output);
+        $this->assertStringContainsString('Models/User', $output);
+        $this->assertStringContainsString('0.0', $output);
+        $this->assertStringNotContainsString('Http/Controllers/Controller', $output);
+        $this->assertStringNotContainsString('100.0', $output);
+        $this->assertStringContainsString('Total: ', $output);
     }
 
     #[Test]

--- a/tests/Unit/Adapters/ArtisanTestCommandTest.php
+++ b/tests/Unit/Adapters/ArtisanTestCommandTest.php
@@ -56,7 +56,7 @@ class ArtisanTestCommandTest extends TestCase
     #[Test]
     public function testHideFullCoverage(): void
     {
-        $output = $this->runTests(['./tests/LaravelApp/artisan', 'test', '--coverage', '--hide-full-coverage', '--group', 'coverage'], 0);
+        $output = $this->runTests(['./tests/LaravelApp/artisan', 'test', '--coverage', '--quiet-coverage', '--group', 'coverage'], 0);
         $this->assertStringContainsString('Code Coverage (files with full coverage not printed):', $output);
         $this->assertStringContainsString('Models/User', $output);
         $this->assertStringContainsString('0.0', $output);


### PR DESCRIPTION
Inspired by this Pinkary post:
https://pinkary.com/@huberfe/questions/9d38b8f9-dc41-46ff-9708-0a6cf90eaac7

If your project has very good code coverage where most files are covered (like the Pinkary project), you may want to remove from the code coverage output all files where coverage is already 100%, allowing you to concentrate on those files which have not reached this level without having to hunt them down amongst a long list of green files

This PR adds a new `--hide-full-coverage` option to the test command. When this option is passed, any file where code coverage is 100% will not be printed in the test output

Also currently the code coverage section did not have any kind of header which explained what was being displayed, I added this header and a little explainer if this option is selected

Once this PR is merged, this option can be added to Pest (and any other testing tool that might use this repository)