### PR TITLE
Add random order seed to test recap

### DIFF
--- a/src/Adapters/Phpunit/Style.php
+++ b/src/Adapters/Phpunit/Style.php
@@ -17,6 +17,7 @@ use PHPUnit\Event\Telemetry\Info;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\IncompleteTestError;
 use PHPUnit\Framework\SkippedWithMessageException;
+use PHPUnit\Runner\TestSuiteSorter;
 use PHPUnit\TestRunner\TestResult\TestResult as PHPUnitTestResult;
 use PHPUnit\TextUI\Configuration\Registry;
 use ReflectionClass;
@@ -267,6 +268,16 @@ final class Style
                 $timeElapsed
             ),
         ]);
+
+        $configuration = Registry::get();
+        if ($configuration->executionOrder() === TestSuiteSorter::ORDER_RANDOMIZED) {
+            $this->output->writeln([
+                sprintf(
+                    '  <fg=gray>Random Order Seed:</> <fg=default>%s</>',
+                    $configuration->randomOrderSeed(),
+                ),
+            ]);
+        }
 
         $this->output->writeln('');
     }

--- a/tests/Unit/Adapters/PhpunitTest.php
+++ b/tests/Unit/Adapters/PhpunitTest.php
@@ -135,6 +135,27 @@ EOF,
             'Tests:    2 deprecated, 2 warnings, 1 risky, 1 incomplete, 2 notices, 1 todo, 1 skipped, 9 passed (16 assertions)',
             $output
         );
+
+        $this->assertConsoleOutputNotContainsString(
+            'Random Order Seed:',
+            $output
+        );
+    }
+
+    #[Test]
+    public function itHasRecapWithRandomOrderSeed(): void
+    {
+        $output = $this->runCollisionTests([
+            '--order-by=random',
+            '--random-order-seed=123',
+            '--exclude-group',
+            'fail,environmentTesting,environmentCustomVariables',
+        ]);
+
+        $this->assertConsoleOutputContainsString(
+            'Random Order Seed: 123',
+            $output
+        );
     }
 
     #[Test]


### PR DESCRIPTION
This PR adds the random order seed to the test recap output, if the order has been set as random (either via `phpunit.xml` or `--order=random`).

This is useful if you have a particular random order that is failing (suggesting an unintended test dependency) and you want to re-test with the same random order (by passing `--random-order-seed=<seed>`)

If you haven't set it to random order then the recap is unchanged and does not include the random order seed.

Example with `--order=random`:
![CleanShot 2024-12-08 at 09 20 03@2x](https://github.com/user-attachments/assets/21b93fa8-9ab1-49d8-83c0-daa2e0449efb)
