### PR TITLE
Add special `dev` to composer keywords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "nunomaduro/collision",
     "description": "Cli error handling for console/command-line PHP applications.",
-    "keywords": ["console", "command-line", "php", "cli", "error", "handling", "laravel-zero", "laravel", "artisan", "symfony"],
+    "keywords": ["console", "command-line", "php", "cli", "error", "handling", "laravel-zero", "laravel", "artisan", "symfony", "dev"],
     "license": "MIT",
     "support": {
         "issues": "https://github.com/nunomaduro/collision/issues",


### PR DESCRIPTION
The special `dev` keyword will warn users who run `composer require nunomaduro/collision` with the following prompt:
```
> composer require nunomaduro/collision
The package you required is recommended to be placed in require-dev (because it is tagged as "dev") but you did not use --dev.
Do you want to re-run the command with --dev? [yes]?
```

See also https://getcomposer.org/doc/04-schema.md#keywords.