### PR TITLE
Removed CHANGELOG.md from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You need to register the handler in your code:
 
 Thank you for considering to contribute to Collision. All the contribution guidelines are mentioned [here](CONTRIBUTING.md).
 
-You can have a look at the [CHANGELOG](CHANGELOG.md) for constant updates & detailed information about the changes. You can also follow the twitter account for latest announcements or just come say hi!: [@enunomaduro](https://twitter.com/enunomaduro)
+You can also follow the twitter account for latest announcements or just come say hi!: [@enunomaduro](https://twitter.com/enunomaduro)
 
 ## License
 


### PR DESCRIPTION
You seem to not have a CHANGELOG.md in your v8.x branch. I think you can remove this from your readme.