### PR TITLE
Do not Suppress Warnings (v8.x)

### DIFF
--- a/src/Adapters/Phpunit/Printers/DefaultPrinter.php
+++ b/src/Adapters/Phpunit/Printers/DefaultPrinter.php
@@ -265,9 +265,7 @@ final class DefaultPrinter
      */
     public function testRunnerWarningTriggered(TestRunnerWarningTriggered $event): void
     {
-        if (! str_starts_with($event->message(), 'No tests found in class')) {
-            $this->style->writeWarning($event->message());
-        }
+        $this->style->writeWarning($event->message());
     }
 
     /**

--- a/tests/TestEmptyCaseWithStdoutOutput/EmptyTest.php
+++ b/tests/TestEmptyCaseWithStdoutOutput/EmptyTest.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class EmptyTest extends TestCase { }

--- a/tests/TestEmptyCaseWithStdoutOutput/phpunit.xml
+++ b/tests/TestEmptyCaseWithStdoutOutput/phpunit.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         beStrictAboutOutputDuringTests="true"
+         cacheResult="false" />

--- a/tests/Unit/Adapters/PhpunitTest.php
+++ b/tests/Unit/Adapters/PhpunitTest.php
@@ -256,4 +256,27 @@ OUTPUT
             $process->getOutput()
         );
     }
+
+    #[Test]
+    public function itShowsWarningsOnEmptyTests(): void
+    {
+        $process = new Process([
+            './vendor/bin/pest',
+            '-c',
+            'tests/LaravelApp/phpunit.xml',
+            'tests/TestEmptyCaseWithStdoutOutput',
+            '--disallow-test-output',
+        ], __DIR__.'/../../..', [
+            'COLLISION_PRINTER' => 'DefaultPrinter',
+            'COLLISION_IGNORE_DURATION' => 'true',
+        ]);
+
+        $process->run();
+
+        $basePath = getcwd();
+
+        $this->assertConsoleOutputContainsString("WARN  No tests found", $process->getOutput()
+        );
+
+    }
 }


### PR DESCRIPTION
This is a fix for #293. Warnings should not be suppressed, unless you also suppress the output on STDERR.