### PR TITLE
[7.x] possible fix for $__latestDescription error

### DIFF
--- a/src/Adapters/Phpunit/TestResult.php
+++ b/src/Adapters/Phpunit/TestResult.php
@@ -200,9 +200,9 @@ final class TestResult
      */
     public static function makeDescription(TestMethod $test): string
     {
-        if (is_subclass_of($test->className(), HasPrintableTestCaseName::class)) {
-            return $test->className()::getLatestPrintableTestCaseMethodName();
-        }
+        // if (is_subclass_of($test->className(), HasPrintableTestCaseName::class)) {
+        //     return $test->className()::getLatestPrintableTestCaseMethodName();
+        // }
 
         $name = $test->name();
 
@@ -215,11 +215,14 @@ final class TestResult
         // Finally, if it starts with `test`, we remove it.
         $name = (string) preg_replace('/^test/', '', $name);
 
-        // Removes spaces
-        $name = trim($name);
-
         // Lower case everything
         $name = mb_strtolower($name);
+
+        // Remove possible pest evaluable prefix
+        $name = str_replace('pest evaluable', '', $name);
+
+        // Removes spaces
+        $name = trim($name);
 
         return $name;
     }


### PR DESCRIPTION
possible fix for $__latestDescription must not be accessed before initialization

https://github.com/pestphp/pest/issues/978

we can't rely on the latest test description as a test might not have run yet, or in the case of multiple failed tests all the tests might show the latest working test name (failed or passed - working as in no uncaught exceptions)


```php
dataset('sample data', function () {
    throw new \Exception('test');

    return [1, 2, 3];
});

test('first', function () {
    expect(true)->toBeTrue();
});

test('second', function () {
    expect(true)->toBeTrue();
});


test('sample', function () {
    expect(true)->toBeTrue();
})->with('sample data');

test('sample 2', function () {
    expect(true)->toBeTrue();
})->with('sample data');
```

BEFORE:

```
   FAIL  Tests\Unit\DatasetTest
  ⨯ second
  ⨯ second
  ✓ first
  ✓ second

   PASS  Tests\Unit\ExampleTest
  ✓ that true is true

   PASS  Tests\Feature\ExampleTest
  ✓ the application returns a successful response                                                                                                  0.05s  
  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────  
   FAILED  Tests\Unit\DatasetTest > second                                                                                                                
  The data provider specified for P\Tests\Unit\DatasetTest::__pest_evaluable_sample is invalid
test

  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────  
   FAILED  Tests\Unit\DatasetTest > second                                                                                                                
  The data provider specified for P\Tests\Unit\DatasetTest::__pest_evaluable_sample_2 is invalid
test

 ```
 
 AFTER:
 ```
   FAIL  Tests\Unit\DatasetTest
  ⨯ sample
  ⨯ sample 2
  ✓ first                                                                                                                                          0.01s  
  ✓ second

   PASS  Tests\Unit\ExampleTest
  ✓ that true is true                                                                                                                              0.01s  

   PASS  Tests\Feature\ExampleTest
  ✓ the application returns a successful response                                                                                                  0.07s  
  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────  
   FAILED  Tests\Unit\DatasetTest > sample                                                                                                                
  The data provider specified for P\Tests\Unit\DatasetTest::__pest_evaluable_sample is invalid
test

  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────  
   FAILED  Tests\Unit\DatasetTest > sample 2                                                                                                              
  The data provider specified for P\Tests\Unit\DatasetTest::__pest_evaluable_sample_2 is invalid
test
  ```
  
  (I only tested this on v8)