### PR TITLE
Fix issue where order of CLI arguments matters

### DIFF
--- a/src/Adapters/Laravel/Commands/TestCommand.php
+++ b/src/Adapters/Laravel/Commands/TestCommand.php
@@ -104,7 +104,7 @@ class TestCommand extends Command
         ),
             null,
             // Envs ...
-            $parallel ? $this->paratestEnvironmentVariables() : $this->phpunitEnvironmentVariables(),
+            $parallel ? $this->paratestEnvironmentVariables($options) : $this->phpunitEnvironmentVariables($options),
         ))->setTimeout(null);
 
         try {
@@ -296,17 +296,17 @@ class TestCommand extends Command
      *
      * @return array
      */
-    protected function phpunitEnvironmentVariables()
+    protected function phpunitEnvironmentVariables($options)
     {
         $variables = [
             'COLLISION_PRINTER' => 'DefaultPrinter',
         ];
 
-        if ($this->option('compact')) {
+        if (in_array('--compact', $options)) {
             $variables['COLLISION_PRINTER_COMPACT'] = 'true';
         }
 
-        if ($this->option('profile')) {
+        if (in_array('--profile', $options)) {
             $variables['COLLISION_PRINTER_PROFILE'] = 'true';
         }
 
@@ -318,13 +318,13 @@ class TestCommand extends Command
      *
      * @return array
      */
-    protected function paratestEnvironmentVariables()
+    protected function paratestEnvironmentVariables($options)
     {
         return [
             'LARAVEL_PARALLEL_TESTING' => 1,
-            'LARAVEL_PARALLEL_TESTING_RECREATE_DATABASES' => $this->option('recreate-databases'),
-            'LARAVEL_PARALLEL_TESTING_DROP_DATABASES' => $this->option('drop-databases'),
-            'LARAVEL_PARALLEL_TESTING_WITHOUT_DATABASES' => $this->option('without-databases'),
+            'LARAVEL_PARALLEL_TESTING_RECREATE_DATABASES' => in_array('--recreate-databases', $options),
+            'LARAVEL_PARALLEL_TESTING_DROP_DATABASES' => in_array('--drop-databases', $options),
+            'LARAVEL_PARALLEL_TESTING_WITHOUT_DATABASES' => in_array('--without-databases', $options),
         ];
     }
 

--- a/tests/LaravelApp/app/Console/Commands/TestCommand.php
+++ b/tests/LaravelApp/app/Console/Commands/TestCommand.php
@@ -54,11 +54,11 @@ class TestCommand extends BaseTestCommand
      *
      * @return array
      */
-    protected function phpunitEnvironmentVariables()
+    protected function phpunitEnvironmentVariables($options)
     {
         if ($this->option('custom-argument')) {
             return array_merge(
-                parent::phpunitEnvironmentVariables(),
+                parent::phpunitEnvironmentVariables($options),
                 [
                     'CUSTOM_ENV_VARIABLE' => 1,
                     'CUSTOM_ENV_VARIABLE_FOR_PHPUNIT' => 1,
@@ -66,7 +66,7 @@ class TestCommand extends BaseTestCommand
             );
         }
 
-        return parent::phpunitEnvironmentVariables();
+        return parent::phpunitEnvironmentVariables($options);
     }
 
     /**
@@ -74,11 +74,11 @@ class TestCommand extends BaseTestCommand
      *
      * @return array
      */
-    protected function paratestEnvironmentVariables()
+    protected function paratestEnvironmentVariables($options)
     {
         if ($this->option('custom-argument')) {
             return array_merge(
-                parent::paratestEnvironmentVariables(),
+                parent::paratestEnvironmentVariables($options),
                 [
                     'CUSTOM_ENV_VARIABLE' => 1,
                     'CUSTOM_ENV_VARIABLE_FOR_PARALLEL' => 1,
@@ -86,7 +86,7 @@ class TestCommand extends BaseTestCommand
             );
         }
 
-        return parent::paratestEnvironmentVariables();
+        return parent::paratestEnvironmentVariables($options);
     }
 
     /**


### PR DESCRIPTION
Hi @nunomaduro ,

Thanks for maintaining this project! Hopefully I have explained my change in enough detail below but please let me know if it needs further explanation or changes.

---

The TestCommand uses ignoreValidationErrors to allow it to accept and pass through arbitrary options to phpunit/paratest. For example it does not define `--stop-on-error` but can pass it through to phpunit.

A side effect of this is that the order of options matters, e.g. 

`php artisan test -p --recreate-databases --stop-on-error` does recreate databases, while

`php artisan test -p --stop-on-error --recreate-databases` does not.

This appears to be because when the validator hits an option it does not know about, it stops processing and any subsequent options cannot be resolved via $this->option.

It looks like this was previously handled when passing through options to phpunit/paratest but was not handled when setting environment variables, this change fixes that.