### PR TITLE
Add support for `AfterLastTestMethodErrored` for use in Pest

### DIFF
--- a/src/Adapters/Phpunit/Printers/DefaultPrinter.php
+++ b/src/Adapters/Phpunit/Printers/DefaultPrinter.php
@@ -14,6 +14,7 @@ use NunoMaduro\Collision\Exceptions\TestOutcome;
 use Pest\Result;
 use PHPUnit\Event\Code\TestMethod;
 use PHPUnit\Event\Code\ThrowableBuilder;
+use PHPUnit\Event\Test\AfterLastTestMethodErrored;
 use PHPUnit\Event\Test\BeforeFirstTestMethodErrored;
 use PHPUnit\Event\Test\ConsideredRisky;
 use PHPUnit\Event\Test\DeprecationTriggered;
@@ -206,6 +207,14 @@ final class DefaultPrinter
 
             $this->state->moveTo($test);
         }
+    }
+
+    /**
+     * Listen to the test errored event.
+     */
+    public function testAfterLastTestMethodErrored(AfterLastTestMethodErrored $event): void
+    {
+        $this->state->add(TestResult::fromAfterLastTestMethodErrored($event));
     }
 
     /**

--- a/src/Adapters/Phpunit/Subscribers/EnsurePrinterIsRegisteredSubscriber.php
+++ b/src/Adapters/Phpunit/Subscribers/EnsurePrinterIsRegisteredSubscriber.php
@@ -9,6 +9,8 @@ use NunoMaduro\Collision\Adapters\Phpunit\Printers\ReportablePrinter;
 use PHPUnit\Event\Application\Started;
 use PHPUnit\Event\Application\StartedSubscriber;
 use PHPUnit\Event\Facade;
+use PHPUnit\Event\Test\AfterLastTestMethodErrored;
+use PHPUnit\Event\Test\AfterLastTestMethodErroredSubscriber;
 use PHPUnit\Event\Test\BeforeFirstTestMethodErrored;
 use PHPUnit\Event\Test\BeforeFirstTestMethodErroredSubscriber;
 use PHPUnit\Event\Test\ConsideredRisky;
@@ -124,6 +126,14 @@ if (class_exists(Version::class) && (int) Version::series() >= 10) {
                 },
 
                 // Test > Hook Methods
+
+                new class($printer) extends Subscriber implements AfterLastTestMethodErroredSubscriber
+                {
+                    public function notify(AfterLastTestMethodErrored $event): void
+                    {
+                        $this->printer()->testAfterLastTestMethodErrored($event);
+                    }
+                },
 
                 new class($printer) extends Subscriber implements BeforeFirstTestMethodErroredSubscriber
                 {

--- a/src/Adapters/Phpunit/TestResult.php
+++ b/src/Adapters/Phpunit/TestResult.php
@@ -9,6 +9,7 @@ use NunoMaduro\Collision\Exceptions\ShouldNotHappen;
 use PHPUnit\Event\Code\Test;
 use PHPUnit\Event\Code\TestMethod;
 use PHPUnit\Event\Code\Throwable;
+use PHPUnit\Event\Test\AfterLastTestMethodErrored;
 use PHPUnit\Event\Test\BeforeFirstTestMethodErrored;
 
 /**
@@ -173,9 +174,9 @@ final class TestResult
     }
 
     /**
-     * Creates a new test from the given test case.
+     * Creates a new test from the given test error event.
      */
-    public static function fromBeforeFirstTestMethodErrored(BeforeFirstTestMethodErrored $event): self
+    public static function fromTestErrorEvent(AfterLastTestMethodErrored|BeforeFirstTestMethodErrored $event): self
     {
         if (is_subclass_of($event->testClassName(), HasPrintableTestCaseName::class)) {
             $testCaseName = $event->testClassName()::getPrintableTestCaseName();
@@ -194,6 +195,22 @@ final class TestResult
         $compactColor = self::makeCompactColor(self::FAIL);
 
         return new self($testCaseName, $testCaseName, $description, self::FAIL, $icon, $compactIcon, $color, $compactColor, [], $event->throwable());
+    }
+
+    /**
+     * Creates a new test from a AfterLastTestMethodErrored event.
+     */
+    public static function fromAfterLastTestMethodErrored(AfterLastTestMethodErrored $event): self
+    {
+        return self::fromTestErrorEvent($event);
+    }
+
+    /**
+     * Creates a new test from a BeforeFirstTestMethodErrored event.
+     */
+    public static function fromBeforeFirstTestMethodErrored(BeforeFirstTestMethodErrored $event): self
+    {
+        return self::fromTestErrorEvent($event);
     }
 
     /**


### PR DESCRIPTION
I've been running into an error in Pest 4 that was reported a while [back in 3.7.2](https://github.com/pestphp/pest/issues/1386) where   `AfterLastTestMethodErrored` events are being passed into `fromBeforeFirstTestMethodErrored`. 

Though the original issue was closed, if we look at Pest's source, it is simply ignoring a PHPStan error that this could happen. 

```php
} else {
    // @phpstan-ignore-next-line
    $state->add(TestResult::fromBeforeFirstTestMethodErrored($testResultEvent));
}
```

https://github.com/pestphp/pest/blob/08b09f2e98fc6830050c0237968b233768642d46/src/Support/StateGenerator.php#L34

To resolve this issue in Pest, Collision must support both kinds of test errors. 

Because these errors seem like they can be handled in a common way, I created a single function that can receive both, but then kept the specific ones to not break backwards compatibility. 

Pest could then take advantage of that single function to handle both cases and remove the PHPStan ignore

```php
} else {
    $state->add(TestResult::fromTestErrorEvent($testResultEvent));
}
```

If this gets published I can follow up with the Pest PR in that repository. 