### PR TITLE
Add PHP 8.5 compatibility

### DIFF
--- a/src/Adapters/Phpunit/ConfigureIO.php
+++ b/src/Adapters/Phpunit/ConfigureIO.php
@@ -34,7 +34,6 @@ final class ConfigureIO
         $application = new Application;
         $reflector = new ReflectionObject($application);
         $method = $reflector->getMethod('configureIO');
-        $method->setAccessible(true);
         $method->invoke($application, $input, $output);
     }
 }

--- a/tests/Unit/Adapters/LaravelTest.php
+++ b/tests/Unit/Adapters/LaravelTest.php
@@ -110,7 +110,6 @@ class LaravelTest extends TestCase
     public function is_inspector_gets_trace(): void
     {
         $method = new ReflectionMethod(Inspector::class, 'getTrace');
-        $method->setAccessible(true);
 
         $exception = new Exception('Foo');
 


### PR DESCRIPTION
Removes unnecessary `ReflectionProperty::setAccessible(true)` call.