### PR TITLE
Add support for `symfony/console ^8.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^8.2.0",
         "filp/whoops": "^2.18.1",
         "nunomaduro/termwind": "^2.3.1",
-        "symfony/console": "^7.3.0"
+        "symfony/console": "^7.3.0 || ^8.0"
     },
     "conflict": {
         "laravel/framework": "<11.44.2 || >=13.0.0",


### PR DESCRIPTION
## Summary

- Add support for `symfony/console ^8.0`

Depends on https://github.com/nunomaduro/termwind/pull/205

## Testing with symfony/console 8.0

To test locally with symfony/console 8.0 while dependencies (like Laravel) don't support it yet, I use the `provide` hack in `composer.json`:

```json
"require": {
    "symfony/console": "^8.0"
},
"provide": {
    "symfony/console": "7.99"
}
```

This tells Composer to virtually provide symfony/console 7.99 (satisfying dependencies requiring `^7.x`) while still installing the actual 8.0 version.

## Tests

Core unit tests pass with symfony/console 8.0:

```bash
./vendor/bin/pest tests/Unit/HandlerTest.php tests/Unit/ProviderTest.php \
  tests/Unit/ArgumentFormatterTest.php tests/Unit/WriterTest.php \
  tests/Unit/TestExceptionTest.php
```

```
PASS  Tests\Unit\HandlerTest
PASS  Tests\Unit\ProviderTest
PASS  Tests\Unit\ArgumentFormatterTest
PASS  Tests\Unit\WriterTest
PASS  Tests\Unit\TestExceptionTest

Tests: 20 passed
```

Laravel-related tests (`ArtisanTestCommandTest`, etc.) fail due to Laravel framework not yet supporting symfony/console 8.0 (`Illuminate\Console\Application::add()` uses `#[\Override]` but parent method was renamed to `addCommand()` in Symfony 8.0).

This PR permits to non-laravel user to use this package with symfony 8 console component.

Thanx