### PR TITLE
Support PHPUnit 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,12 +78,16 @@ jobs:
         php: ['8.2', '8.3', '8.4', '8.5']
         laravel: ['11.0', '12.0']
         symfony: ['7.4', '8.0']
-        phpunit: ['11.0.0', '12.0.0']
+        phpunit: ['11.0.0', '12.0.0', '13.0.0']
         dependency-version: [prefer-stable]
         exclude:
           - symfony: '8.0' # pending laravel 13...
           - php: '8.2'
             phpunit: '12.0.0'
+          - php: '8.2'
+            phpunit: '13.0.0'
+          - php: '8.3'
+            phpunit: '13.0.0'
 
     name: PHP ${{ matrix.php }} - ${{ matrix.os }} - PHPUnit ${{ matrix.phpunit }} - Laravel ${{ matrix.laravel }} - Symfony ${{ matrix.symfony }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "conflict": {
         "laravel/framework": "<11.48.0 || >=14.0.0",
-        "phpunit/phpunit": "<11.5.50 || >=13.0.0"
+        "phpunit/phpunit": "<11.5.50 || >=14.0.0"
     },
     "require-dev": {
         "brianium/paratest": "^7.8.5",


### PR DESCRIPTION
See also https://phpunit.de/announcements/phpunit-13.html.

## To Do

- [ ] Wait for upstream support
  - [x] https://github.com/paratestphp/paratest/releases/tag/v7.18.0
  - [ ] Pest; see https://github.com/pestphp/pest/blob/4.x/composer.json#L33
- [ ] Look for further required changes; see also https://github.com/nunomaduro/collision/pull/325