### PR TITLE
Add support for `phpunit.dist.xml` configuration file

### DIFF
--- a/src/Adapters/Laravel/Commands/TestCommand.php
+++ b/src/Adapters/Laravel/Commands/TestCommand.php
@@ -234,8 +234,16 @@ class TestCommand extends Command
      */
     protected function getConfigurationFile()
     {
-        if (! file_exists($file = base_path('phpunit.xml'))) {
-            $file = base_path('phpunit.xml.dist');
+        $candidates = [
+            'phpunit.xml',
+            'phpunit.dist.xml',
+            'phpunit.xml.dist',
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (file_exists($file = base_path($candidate))) {
+                break;
+            }
         }
 
         return $file;


### PR DESCRIPTION
This PR adds support for recognizing `phpunit.dist.xml`, which was introduced in PHPUnit 10.

Currently, `phpunit.xml` and `phpunit.xml.dist` are supported, but `phpunit.dist.xml` is not. This PR adds `phpunit.dist.xml` as a resolution target and aligns the lookup order with PHPUnit:

1. `phpunit.xml`
2. `phpunit.dist.xml`
3. `phpunit.xml.dist`

* https://docs.phpunit.de/en/12.5/textui.html#configuration
* https://github.com/sebastianbergmann/phpunit/blob/10.0.0/src/TextUI/Configuration/Cli/XmlConfigurationFileFinder.php#L54-L56