### PR TITLE
Flush previous test case summary on pre-prep events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^8.2.0",
         "filp/whoops": "^2.18.4",
         "nunomaduro/termwind": "^2.4.0",
-        "symfony/console": "^7.4.8 || ^8.0.8"
+        "symfony/console": "^7.4.9 || ^8.0.9"
     },
     "conflict": {
         "laravel/framework": "<11.48.0 || >=14.0.0",
@@ -25,12 +25,12 @@
     },
     "require-dev": {
         "brianium/paratest": "^7.8.5",
-        "laravel/framework": "^11.48.0 || ^12.56.0 || ^13.5.0",
+        "laravel/framework": "^11.48.0 || ^12.56.0 || ^13.7.0",
         "laravel/pint": "^1.29.1",
         "larastan/larastan": "^3.9.6",
-        "orchestra/testbench-core": "^9.12.0 || ^10.12.1 || ^11.2.1",
-        "pestphp/pest": "^3.8.5 || ^4.4.3 || ^5.0.0",
-        "sebastian/environment": "^7.2.1 || ^8.0.4 || ^9.3.0"
+        "orchestra/testbench-core": "^9.12.0 || ^10.12.1 || ^11.3.1",
+        "pestphp/pest": "^3.8.5 || ^4.6.3 || ^5.0.0",
+        "sebastian/environment": "^7.2.1 || ^8.1.0 || ^9.3.0"
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/Adapters/Phpunit/Printers/DefaultPrinter.php
+++ b/src/Adapters/Phpunit/Printers/DefaultPrinter.php
@@ -237,6 +237,22 @@ final class DefaultPrinter
             throw new ShouldNotHappen;
         }
 
+        $this->ensureCaseBoundary($test);
+    }
+
+    /**
+     * Flush the previous test case summary if the given test belongs to a new case.
+     *
+     * Some PHPUnit events (e.g. deprecation triggers from class autoloading) fire
+     * for a test before its `testPreparationStarted`. Without flushing here, the
+     * previous case's tests would be silently merged under the new case's header.
+     */
+    private function ensureCaseBoundary(\PHPUnit\Event\Code\Test $test): void
+    {
+        if (! $test instanceof TestMethod) {
+            return;
+        }
+
         if ($this->state->testCaseHasChanged($test)) {
             $this->style->writeCurrentTestCaseSummary($this->state);
 
@@ -313,6 +329,7 @@ final class DefaultPrinter
     {
         $throwable = ThrowableBuilder::from(new TestOutcome($event->message()));
 
+        $this->ensureCaseBoundary($event->test());
         $this->state->add(TestResult::fromTestCase($event->test(), TestResult::DEPRECATED, $throwable));
     }
 
@@ -323,6 +340,7 @@ final class DefaultPrinter
     {
         $throwable = ThrowableBuilder::from(new TestOutcome($event->message()));
 
+        $this->ensureCaseBoundary($event->test());
         $this->state->add(TestResult::fromTestCase($event->test(), TestResult::NOTICE, $throwable));
     }
 
@@ -333,6 +351,7 @@ final class DefaultPrinter
     {
         $throwable = ThrowableBuilder::from(new TestOutcome($event->message()));
 
+        $this->ensureCaseBoundary($event->test());
         $this->state->add(TestResult::fromTestCase($event->test(), TestResult::WARN, $throwable));
     }
 
@@ -343,6 +362,7 @@ final class DefaultPrinter
     {
         $throwable = ThrowableBuilder::from(new TestOutcome($event->message()));
 
+        $this->ensureCaseBoundary($event->test());
         $this->state->add(TestResult::fromTestCase($event->test(), TestResult::WARN, $throwable));
     }
 
@@ -353,6 +373,7 @@ final class DefaultPrinter
     {
         $throwable = ThrowableBuilder::from(new TestOutcome($event->message()));
 
+        $this->ensureCaseBoundary($event->test());
         $this->state->add(TestResult::fromTestCase($event->test(), TestResult::DEPRECATED, $throwable));
     }
 
@@ -363,6 +384,7 @@ final class DefaultPrinter
     {
         $throwable = ThrowableBuilder::from(new TestOutcome($event->message()));
 
+        $this->ensureCaseBoundary($event->test());
         $this->state->add(TestResult::fromTestCase($event->test(), TestResult::DEPRECATED, $throwable));
     }
 
@@ -383,6 +405,7 @@ final class DefaultPrinter
     {
         $throwable = ThrowableBuilder::from(new TestOutcome($event->message()));
 
+        $this->ensureCaseBoundary($event->test());
         $this->state->add(TestResult::fromTestCase($event->test(), TestResult::NOTICE, $throwable));
     }
 
@@ -393,6 +416,7 @@ final class DefaultPrinter
     {
         $throwable = ThrowableBuilder::from(new TestOutcome($event->message()));
 
+        $this->ensureCaseBoundary($event->test());
         $this->state->add(TestResult::fromTestCase($event->test(), TestResult::WARN, $throwable));
     }
 


### PR DESCRIPTION
## Summary

Fixes a printer-grouping bug where tests from one test case can be rendered under the **next** test case's header when a deprecation/notice/warning event fires before that test's `testPreparationStarted`.

### Repro

Easy to hit with Pest's TIA `--filtered` mode (which runs only a subset of files), where a class autoloaded inside the first executed test of a new file emits a PHP deprecation. Example output before the fix:

```
WARN  Tests\Unit\Http\Props\DeploymentStepsPropsTest
! it produces coherent vars … "PHP"   ← actually RecipeCoherenceTest
! it produces coherent vars … "Node"  ← actually RecipeCoherenceTest
! it fetches each log file from S3 …  ← real DeploymentSteps test
…
```

The two `produces coherent vars` cases live in `RecipeCoherenceTest`, but they're rendered under the `DeploymentStepsPropsTest` `WARN` header.

### Root cause

`testDeprecationTriggered` (and other `*DeprecationTriggered` / `*NoticeTriggered` / `*WarningTriggered` events) can fire for the upcoming test **before** Collision sees `testPreparationStarted` — autoloading a class inside the test triggers `E_USER_DEPRECATED` early in the test lifecycle.

`testPreparationStarted` is the only place doing the case-boundary flush:

```php
if ($this->state->testCaseHasChanged($test)) {
    $this->style->writeCurrentTestCaseSummary($this->state);
    $this->state->moveTo($test);
}
```

Meanwhile, `State::add()` (line 68) unconditionally sets `state->testCaseName = $test->testCaseName`. So the early deprecation event for the new test silently overwrites `testCaseName`, and when prep finally runs `testCaseHasChanged()` returns `false`. The previous case's tests stay in `toBePrintedCaseTests` and get rendered under whatever header is printed next.

I traced this in a real run and confirmed the order:

```
[DEPRTRIG] Recipe::PHP                ← deprecation arrives first
[PREP] Recipe::PHP                    ← prep
[DEPRTRIG] DeploymentSteps::keys      ← new-case deprecation BEFORE its prep
[PREP] DeploymentSteps::keys
```

### Fix

Extract the boundary-flush from `testPreparationStarted` into a private `ensureCaseBoundary(Test $test)` helper, and call it before `state->add(...)` in every event handler whose payload carries `DEPRECATED` / `NOTICE` / `WARN` (the events that can land before prep):

- `testPhpDeprecationTriggered`
- `testPhpNoticeTriggered`
- `testPhpWarningTriggered`
- `testPhpunitWarningTriggered`
- `testDeprecationTriggered`
- `testPhpunitDeprecationTriggered`
- `testNoticeTriggered`
- `testWarningTriggered`

Idempotent for the common case: when prep fires later for the same test, `testCaseHasChanged()` returns `false` and nothing happens.

After the fix:

```
WARN  Tests\Unit\Domain\Runtime\Build\RecipeCoherenceTest
! it produces coherent vars … "PHP"
! it produces coherent vars … "Node"

WARN  Tests\Unit\Http\Props\DeploymentStepsPropsTest
! it fetches each log file from S3 …
! deployment steps → keys
…
```

## Test plan

- [ ] Existing collision/Pest test suite passes
- [ ] Manual repro on Pest `--tia --filtered` no longer mis-groups tests
- [ ] No change to output for runs where deprecation events fire only after `testPreparationStarted`