### PR TITLE
Prevent duplicate configuration option

### DIFF
--- a/src/Adapters/Laravel/Commands/TestCommand.php
+++ b/src/Adapters/Laravel/Commands/TestCommand.php
@@ -226,6 +226,10 @@ class TestCommand extends Command
                 && ! Str::startsWith($option, '--min');
         }));
 
+        if (! empty(preg_grep('/^(--configuration|-c)/', $options))) {
+            return array_merge($this->commonArguments(), $options);
+        }
+
         return array_merge($this->commonArguments(), ['--configuration='.$this->getConfigurationFile()], $options);
     }
 

--- a/tests/Unit/Adapters/ArtisanTestCommandTest.php
+++ b/tests/Unit/Adapters/ArtisanTestCommandTest.php
@@ -66,6 +66,21 @@ class ArtisanTestCommandTest extends TestCase
     }
 
     #[Test]
+    public function test_configuration(): void
+    {
+        $output = $this->runTests([
+            './tests/LaravelApp/artisan',
+            'test',
+            '--configuration',
+            'tests/LaravelApp/phpunit.xml',
+            '--group',
+            'environment',
+        ]);
+
+        $this->assertStringNotContainsString('cannot be used more than once', $output);
+    }
+
+    #[Test]
     public function test_env(): void
     {
         if (file_exists('./vendor/bin/pest')) {


### PR DESCRIPTION
Running `php artisan test` with an explicit `--configuration` (or `-c`) currently shows PHPUnit's `Option "--configuration" cannot be used more than once` warning, because Collision always appends its own configuration on top of the one passed by the user. This only appends the default configuration when the user hasn't already provided one.

Fixes #346
