### PR TITLE
feat: make profile slow test count configurable

### DIFF
--- a/src/Adapters/Phpunit/Printers/DefaultPrinter.php
+++ b/src/Adapters/Phpunit/Printers/DefaultPrinter.php
@@ -81,6 +81,11 @@ final class DefaultPrinter
     private static bool $profile = false;
 
     /**
+     * The number of slowest tests to display when profiling.
+     */
+    private static int $profileSlowTestsCount = 10;
+
+    /**
      * When profiling, holds a list of slow tests.
      */
     private array $profileSlowTests = [];
@@ -142,6 +147,18 @@ final class DefaultPrinter
         }
 
         return self::$profile;
+    }
+
+    /**
+     * The number of slowest tests to display when profiling.
+     */
+    public static function profileSlowTestsCount(?int $value = null): int
+    {
+        if (! is_null($value)) {
+            self::$profileSlowTestsCount = $value;
+        }
+
+        return self::$profileSlowTestsCount;
     }
 
     /**
@@ -216,12 +233,12 @@ final class DefaultPrinter
         if (self::$profile) {
             $this->profileSlowTests[$event->test()->id()] = $result;
 
-            // Sort the slow tests by time, and keep only 10 of them.
+            // Sort the slow tests by time, and keep only the configured number of them.
             uasort($this->profileSlowTests, static function (TestResult $a, TestResult $b) {
                 return $b->duration <=> $a->duration;
             });
 
-            $this->profileSlowTests = array_slice($this->profileSlowTests, 0, 10);
+            $this->profileSlowTests = array_slice($this->profileSlowTests, 0, self::$profileSlowTestsCount);
         }
     }
 

--- a/tests/Unit/Adapters/PhpunitTest.php
+++ b/tests/Unit/Adapters/PhpunitTest.php
@@ -23,6 +23,7 @@ class PhpunitTest extends TestCase
     protected function tearDown(): void
     {
         DefaultPrinter::flushRecapCallbacks();
+        DefaultPrinter::profileSlowTestsCount(10);
     }
 
     #[Test]
@@ -47,6 +48,16 @@ class PhpunitTest extends TestCase
         DefaultPrinter::flushRecapCallbacks();
 
         $this->assertSame([], DefaultPrinter::recapCallbacks());
+    }
+
+    #[Test]
+    public function it_configures_the_profile_slow_tests_count(): void
+    {
+        $this->assertSame(10, DefaultPrinter::profileSlowTestsCount());
+
+        $this->assertSame(5, DefaultPrinter::profileSlowTestsCount(5));
+
+        $this->assertSame(5, DefaultPrinter::profileSlowTestsCount());
     }
 
     private function stripConsoleOutput(string $consoleOutput)


### PR DESCRIPTION
Exposes the number of slowest tests shown in the profile output as a configurable static, so consumers can override the default of 10:

```php
\NunoMaduro\Collision\Adapters\Phpunit\Printers\DefaultPrinter::profileSlowTestsCount(25);
```

No behavior change for existing users — default remains 10.