### PR TITLE
Stop undeclared options from silently dropping the rest of the input

### DIFF
--- a/src/Adapters/Laravel/Commands/TestCommand.php
+++ b/src/Adapters/Laravel/Commands/TestCommand.php
@@ -18,6 +18,9 @@ use RuntimeException;
 use SebastianBergmann\Environment\Console;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Exception\ProcessSignaledException;
 use Symfony\Component\Process\Process;
 
@@ -63,6 +66,62 @@ class TestCommand extends Command
         parent::__construct();
 
         $this->ignoreValidationErrors();
+    }
+
+    /**
+     * Run the console command.
+     */
+    public function run(InputInterface $input, OutputInterface $output): int
+    {
+        $this->registerForwardedOptions();
+
+        return parent::run($input, $output);
+    }
+
+    /**
+     * Declare the options that are only meant to be forwarded to the underlying
+     * test runner.
+     *
+     * Options such as ParaTest's `--processes` are not part of this command's
+     * definition. Because the command ignores validation errors, Symfony's
+     * parser stops at the first one it does not know and silently drops every
+     * token after it, so the command still runs but with the wrong options.
+     * Declaring them up front keeps the whole input parsable.
+     */
+    protected function registerForwardedOptions(): void
+    {
+        // The application options are merged in as well, so that an option this
+        // command does not declare itself, such as `--env`, is not mistaken for
+        // one that needs declaring. Options are added to the native definition
+        // because `run()` rebuilds the merged one from it.
+        $this->mergeApplicationDefinition();
+
+        $definition = $this->getDefinition();
+        $nativeDefinition = $this->getNativeDefinition();
+
+        $tokens = $_SERVER['argv'] ?? [];
+
+        if (! is_array($tokens)) {
+            return;
+        }
+
+        foreach ($tokens as $token) {
+            if (! is_string($token) || $token === '--' || ! str_starts_with($token, '--')) {
+                continue;
+            }
+
+            $name = substr($token, 2);
+
+            if (($position = strpos($name, '=')) !== false) {
+                $name = substr($name, 0, $position);
+            }
+
+            if ($name === '' || $definition->hasOption($name) || $definition->hasNegation($name)) {
+                continue;
+            }
+
+            $nativeDefinition->addOption(new InputOption($name, null, InputOption::VALUE_OPTIONAL));
+        }
     }
 
     /**

--- a/tests/Unit/Adapters/ArtisanTestCommandTest.php
+++ b/tests/Unit/Adapters/ArtisanTestCommandTest.php
@@ -153,6 +153,32 @@ EOF
         $this->runTests(['./tests/LaravelApp/artisan', 'test', '--custom-argument', '--parallel', '--drop-databases', '--group', 'environmentCVParallelDrop']);
     }
 
+    #[Test]
+    public function test_options_after_an_undeclared_option_are_not_lost(): void
+    {
+        // `--processes` belongs to ParaTest and is not part of the Artisan command
+        // definition. Parsing must not stop there, otherwise every option that
+        // follows it is silently dropped while the command still runs.
+        $this->runTests([
+            './tests/LaravelApp/artisan', 'test',
+            '--processes=2',
+            '--parallel',
+            '--recreate-databases',
+            '--custom-argument',
+            '--group', 'environmentCVParallelRecreate',
+        ]);
+
+        // Same for an option that takes its value as a separate token.
+        $this->runTests([
+            './tests/LaravelApp/artisan', 'test',
+            '--processes', '2',
+            '--parallel',
+            '--recreate-databases',
+            '--custom-argument',
+            '--group', 'environmentCVParallelRecreate',
+        ]);
+    }
+
     private function runTests(array $arguments, int $expectedExitCode = 0): string
     {
         $arguments = array_merge($arguments, [


### PR DESCRIPTION
Fixes #362.

## Root cause

`TestCommand` calls `ignoreValidationErrors()` in its constructor so that options destined for the underlying runner can be forwarded. Symfony then swallows the exception raised while binding:

```php
try {
    $input->bind($this->getDefinition());
} catch (ExceptionInterface $e) {
    if (!$this->ignoreValidationErrors) {
        throw $e;
    }
}
```

The catch happens *outside* `ArgvInput::parse()`, which has already abandoned its token loop at the undeclared option. Everything after it is never parsed. The command runs anyway, with silently wrong options.

## Reproduction

Against `tests/LaravelApp`, dumping what the command actually sees:

```
artisan test --processes=2 --parallel --recreate-databases
  -> parallel=false  recreate-databases=false      # everything lost

artisan test --parallel --processes=2 --recreate-databases
  -> parallel=true   recreate-databases=false      # silently wrong
```

The second one is the dangerous case from the issue: ParaTest runs, the run looks healthy, and the databases are simply never recreated.

This is **not limited to ParaTest options**. `--filter` is not part of the command definition either, so this is broken today:

```
artisan test --filter=Foo --parallel --recreate-databases
  -> The "--recreate-databases" option does not exist.
```

## The change

Before Symfony binds the input, walk `argv` and declare every long option the definition does not already know about. Parsing then runs to completion and the command's own options are read correctly.

Details worth noting:

- Options are added to the **native** definition, because `Command::run()` calls `mergeApplicationDefinition()`, which rebuilds the merged definition from the native one and would otherwise discard the additions.
- The merged definition is what gets consulted for "do I already know this option?", so application-level options such as `--env` and `--ansi` are not redeclared. Redeclaring them would throw `LogicException`, since `InputDefinition::addOption()` rejects a differing option with an existing name.
- They are registered `VALUE_OPTIONAL` so that `--processes 2` consumes `2` as its value instead of leaving a stray argument behind, which would trip the "too many arguments" error and abort parsing again.

I considered feeding ParaTest's own definition in via `Options::setInputDefinition()`, which the command already uses further down. I did not go that way: it only covers ParaTest, so `--filter` and other PHPUnit/Pest options stay broken, and it needs revisiting whenever those option lists change.

**Known remainder:** undeclared *short* options (`artisan test -d memory_limit=512M`) still abort parsing. Handling them means inventing long names for synthetic options, which pollutes `--help`, so it felt like a separate decision rather than something to bundle in here. Happy to add it if you'd prefer.

## Tests

`test_options_after_an_undeclared_option_are_not_lost` in `ArtisanTestCommandTest`, covering both `--processes=2` and `--processes 2`. It reuses the existing `environmentCVParallelRecreate` group, which asserts `LARAVEL_PARALLEL_TESTING_RECREATE_DATABASES`, so it fails on `v8.x` and passes here.

Suite goes from 45 to 46 passing. The 4 failures on my machine (`coverage`, `min coverage`, `hide full coverage`, `using xdebug`) are pre-existing on a clean checkout and are down to having no coverage driver installed locally. `pint --test` passes, and `phpstan analyse` reports the same 4 pre-existing errors before and after.
