### PR TITLE
Do not forward --profile to ParaTest

### DIFF
--- a/src/Adapters/Laravel/Commands/TestCommand.php
+++ b/src/Adapters/Laravel/Commands/TestCommand.php
@@ -261,6 +261,7 @@ class TestCommand extends Command
                 && ! Str::startsWith($option, '--min')
                 && ! Str::startsWith($option, '-p')
                 && ! Str::startsWith($option, '--compact')
+                && ! Str::startsWith($option, '--profile')
                 && ! Str::startsWith($option, '--parallel')
                 && ! Str::startsWith($option, '--recreate-databases')
                 && ! Str::startsWith($option, '--drop-databases')

--- a/tests/Unit/Adapters/ArtisanTestCommandTest.php
+++ b/tests/Unit/Adapters/ArtisanTestCommandTest.php
@@ -153,6 +153,19 @@ EOF
         $this->runTests(['./tests/LaravelApp/artisan', 'test', '--custom-argument', '--parallel', '--drop-databases', '--group', 'environmentCVParallelDrop']);
     }
 
+    #[Test]
+    public function test_profile_is_not_forwarded_to_paratest(): void
+    {
+        // `--profile` is passed to the printer through an environment variable,
+        // so ParaTest must never receive it as an argument.
+        $this->runTests([
+            './tests/LaravelApp/artisan', 'test',
+            '--parallel',
+            '--profile',
+            '--group', 'environmentNoCVParallel',
+        ]);
+    }
+
     private function runTests(array $arguments, int $expectedExitCode = 0): string
     {
         $arguments = array_merge($arguments, [


### PR DESCRIPTION
Fixes #327.

`--profile` is passed to the printer via the `COLLISION_PRINTER_PROFILE` env var, so it must not be forwarded as an argument. `phpunitArguments()` already strips it, `paratestArguments()` did not — so `--parallel --profile` failed with `The "--profile" option does not exist.`