### PR TITLE
[8.x] Support an exact code coverage threshold

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -81,7 +81,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$haystack of static method Illuminate\\Support\\Str\:\:startsWith\(\) expects string, mixed given\.$#'
 			identifier: argument.type
-			count: 11
+			count: 13
 			path: src/Adapters/Laravel/Commands/TestCommand.php
 
 		-

--- a/src/Adapters/Laravel/Commands/TestCommand.php
+++ b/src/Adapters/Laravel/Commands/TestCommand.php
@@ -38,6 +38,7 @@ class TestCommand extends Command
         {--compact : Indicates whether the compact printer should be used}
         {--coverage : Indicates whether code coverage information should be collected}
         {--min= : Indicates the minimum threshold enforcement for code coverage}
+        {--exactly= : Indicates the exact threshold enforcement for code coverage}
         {--p|parallel : Indicates if the tests should run in parallel}
         {--profile : Lists top 10 slowest tests}
         {--recreate-databases : Indicates if the test databases should be re-created}
@@ -143,6 +144,19 @@ class TestCommand extends Command
                     number_format($coverage, 1),
                     number_format((float) $this->option('min'), 1)
                 ));
+            } elseif ($this->option('exactly') !== null) {
+                $truncatedExactly = floor((float) $this->option('exactly') * 10) / 10;
+                $truncatedCoverage = floor($coverage * 10) / 10;
+
+                $exitCode = (int) ($truncatedCoverage !== $truncatedExactly);
+
+                if ($exitCode === 1) {
+                    $this->output->writeln(sprintf(
+                        "\n  <fg=white;bg=red;options=bold> FAIL </> Code coverage not exactly:<fg=red;options=bold> %s %%</>. Expected:<fg=white;options=bold> %s %%</>.",
+                        number_format($truncatedCoverage, 1),
+                        number_format($truncatedExactly, 1)
+                    ));
+                }
             }
         }
 
@@ -223,7 +237,8 @@ class TestCommand extends Command
                 && $option != '--profile'
                 && $option != '--ansi'
                 && $option != '--no-ansi'
-                && ! Str::startsWith($option, '--min');
+                && ! Str::startsWith($option, '--min')
+                && ! Str::startsWith($option, '--exactly');
         }));
 
         return array_merge($this->commonArguments(), ['--configuration='.$this->getConfigurationFile()], $options);
@@ -259,6 +274,7 @@ class TestCommand extends Command
                 && $option != '--ansi'
                 && $option != '--no-ansi'
                 && ! Str::startsWith($option, '--min')
+                && ! Str::startsWith($option, '--exactly')
                 && ! Str::startsWith($option, '-p')
                 && ! Str::startsWith($option, '--compact')
                 && ! Str::startsWith($option, '--parallel')

--- a/tests/LaravelApp/app/Console/Commands/TestCommand.php
+++ b/tests/LaravelApp/app/Console/Commands/TestCommand.php
@@ -19,6 +19,7 @@ class TestCommand extends BaseTestCommand
         {--compact : Indicates whether the compact printer should be used}
         {--coverage : Indicates whether code coverage information should be collected}
         {--min= : Indicates the minimum threshold enforcement for code coverage}
+        {--exactly= : Indicates the exact threshold enforcement for code coverage}
         {--quiet-coverage : Do not report any files where code coverage is 100%}
         {--p|parallel : Indicates if the tests should run in parallel}
         {--profile : Lists top 10 slowest tests}

--- a/tests/Unit/Adapters/ArtisanTestCommandTest.php
+++ b/tests/Unit/Adapters/ArtisanTestCommandTest.php
@@ -48,6 +48,26 @@ class ArtisanTestCommandTest extends TestCase
     }
 
     #[Test]
+    public function test_exactly_coverage(): void
+    {
+        $output = $this->runTests(['./tests/LaravelApp/artisan', 'test', '--coverage', '--exactly=0', '--group', 'coverage'], 0);
+        $this->assertStringContainsString('Total: ', $output);
+        $this->assertStringNotContainsString('Code coverage not exactly', $output);
+
+        $output = $this->runTests(['./tests/LaravelApp/artisan', 'test', '--coverage', '--exactly=100', '--group', 'coverage'], 1);
+        $this->assertStringContainsString('Total: ', $output);
+        $this->assertStringContainsString('Code coverage not exactly', $output);
+
+        $output = $this->runTests(['./tests/LaravelApp/artisan', 'test', '--coverage', '--exactly=100', '--parallel', '--group', 'coverage'], 1);
+        $this->assertStringContainsString('Total: ', $output);
+        $this->assertStringContainsString('Code coverage not exactly', $output);
+
+        $output = $this->runTests(['./tests/LaravelApp/artisan', 'test', '--coverage', '--min=99', '--exactly=0', '--group', 'coverage'], 1);
+        $this->assertStringContainsString('Code coverage below expected', $output);
+        $this->assertStringNotContainsString('Code coverage not exactly', $output);
+    }
+
+    #[Test]
     public function test_hide_full_coverage(): void
     {
         $output = $this->runTests(['./tests/LaravelApp/artisan', 'test', '--coverage', '--compact', '--group', 'coverage'], 0);


### PR DESCRIPTION
`--exactly` is a Pest coverage option, but it never has any effect through `php artisan test`. The command strips `--coverage` out of the arguments it forwards and reports coverage itself, so Pest's own check never runs and `php artisan test --coverage --exactly=100` exits 0 even when coverage is far below 100%.

This adds `--exactly` here next to `--min`, so the command that reports the coverage is also the one enforcing the threshold. As a side effect it works for PHPUnit and Paratest runs too, not only Pest ones.

Reported in https://github.com/pestphp/pest/issues/1897.
