### PR TITLE
Delegate shouldStopRetries in Laravel exception handler

### DIFF
--- a/src/Adapters/Laravel/ExceptionHandler.php
+++ b/src/Adapters/Laravel/ExceptionHandler.php
@@ -93,7 +93,9 @@ final class ExceptionHandler implements ExceptionHandlerContract
      */
     public function shouldStopRetries(Throwable $e)
     {
-        return $this->appExceptionHandler->shouldStopRetries($e);
+        return method_exists($this->appExceptionHandler, 'shouldStopRetries')
+            ? $this->appExceptionHandler->shouldStopRetries($e)
+            : false;
     }
 
     /**

--- a/src/Adapters/Laravel/ExceptionHandler.php
+++ b/src/Adapters/Laravel/ExceptionHandler.php
@@ -87,6 +87,16 @@ final class ExceptionHandler implements ExceptionHandlerContract
     }
 
     /**
+     * Determine if the exception should stop job retries.
+     *
+     * @return bool
+     */
+    public function shouldStopRetries(Throwable $e)
+    {
+        return $this->appExceptionHandler->shouldStopRetries($e);
+    }
+
+    /**
      * Register a reportable callback.
      *
      * @return ReportableHandler

--- a/tests/Unit/Adapters/LaravelTest.php
+++ b/tests/Unit/Adapters/LaravelTest.php
@@ -82,6 +82,19 @@ class LaravelTest extends TestCase
     }
 
     #[Test]
+    public function it_delegates_should_stop_retries_to_the_original_exception_handler(): void
+    {
+        $app = $this->createApplication();
+        $exception = new Exception;
+        $originalExceptionHandlerMock = $this->createMock(Handler::class);
+        $originalExceptionHandlerMock->expects($this->once())->method('shouldStopRetries')->with($exception)->willReturn(true);
+
+        $exceptionHandler = new ExceptionHandler($app, $originalExceptionHandlerMock);
+
+        $this->assertTrue($exceptionHandler->shouldStopRetries($exception));
+    }
+
+    #[Test]
     public function it_renders_to_the_original_exception_handler(): void
     {
         $app = $this->createApplication();

--- a/tests/Unit/Adapters/LaravelTest.php
+++ b/tests/Unit/Adapters/LaravelTest.php
@@ -88,10 +88,18 @@ class LaravelTest extends TestCase
         $exception = new Exception;
         $originalExceptionHandlerMock = $this->createMock(Handler::class);
         $originalExceptionHandlerMock->expects($this->once())->method('shouldStopRetries')->with($exception)->willReturn(true);
-
         $exceptionHandler = new ExceptionHandler($app, $originalExceptionHandlerMock);
-
         $this->assertTrue($exceptionHandler->shouldStopRetries($exception));
+    }
+
+    #[Test]
+    public function it_does_not_stop_retries_when_the_original_exception_handler_does_not_support_it(): void
+    {
+        $app = $this->createApplication();
+        $exception = new Exception;
+        $originalExceptionHandlerMock = $this->createMock(ExceptionHandlerContract::class);
+        $exceptionHandler = new ExceptionHandler($app, $originalExceptionHandlerMock);
+        $this->assertFalse($exceptionHandler->shouldStopRetries($exception));
     }
 
     #[Test]


### PR DESCRIPTION
Collision's ExceptionHandler wraps Laravel's default handler but never delegates shouldStopRetries. The queue worker checks method_exists before calling it, so early-fail-by-exception silently does nothing once Collision replaces the handler.

Adds the missing delegating method, same pattern as report()/shouldReport()/render().

Fixes #366