### PR TITLE
fix: do not render issues that PHP suppressed

### DIFF
--- a/src/Adapters/Phpunit/Printers/DefaultPrinter.php
+++ b/src/Adapters/Phpunit/Printers/DefaultPrinter.php
@@ -262,6 +262,36 @@ final class DefaultPrinter
     }
 
     /**
+     * Determine whether an issue PHP suppressed should be ignored.
+     *
+     * PHPUnit reports a suppressed issue only when the matching
+     * `ignoreSuppressionOf*` source setting is enabled, and discards it
+     * otherwise - see `PHPUnit\TestRunner\IssueFilter`. Rendering suppressed
+     * issues regardless does not just show what the user asked PHPUnit to
+     * hide: `ensureCaseBoundary()` flushes output immediately, so a suppressed
+     * issue raised while a class is being autoloaded re-enters the autoloader
+     * from inside the `include` that is still in progress.
+     */
+    private function isIgnoredSuppressedIssue(
+        DeprecationTriggered|NoticeTriggered|PhpDeprecationTriggered|PhpNoticeTriggered|PhpWarningTriggered|WarningTriggered $event,
+    ): bool {
+        if (! $event->wasSuppressed()) {
+            return false;
+        }
+
+        $source = Registry::get()->source();
+
+        return match (true) {
+            $event instanceof PhpDeprecationTriggered => ! $source->ignoreSuppressionOfPhpDeprecations(),
+            $event instanceof DeprecationTriggered => ! $source->ignoreSuppressionOfDeprecations(),
+            $event instanceof PhpNoticeTriggered => ! $source->ignoreSuppressionOfPhpNotices(),
+            $event instanceof NoticeTriggered => ! $source->ignoreSuppressionOfNotices(),
+            $event instanceof PhpWarningTriggered => ! $source->ignoreSuppressionOfPhpWarnings(),
+            $event instanceof WarningTriggered => ! $source->ignoreSuppressionOfWarnings(),
+        };
+    }
+
+    /**
      * Listen to the test errored event.
      */
     public function testBeforeFirstTestMethodErrored(BeforeFirstTestMethodErrored $event): void
@@ -328,6 +358,10 @@ final class DefaultPrinter
      */
     public function testPhpDeprecationTriggered(PhpDeprecationTriggered $event): void
     {
+        if ($this->isIgnoredSuppressedIssue($event)) {
+            return;
+        }
+
         $throwable = ThrowableBuilder::from(new TestOutcome($event->message()));
 
         $this->ensureCaseBoundary($event->test());
@@ -339,6 +373,10 @@ final class DefaultPrinter
      */
     public function testPhpNoticeTriggered(PhpNoticeTriggered $event): void
     {
+        if ($this->isIgnoredSuppressedIssue($event)) {
+            return;
+        }
+
         $throwable = ThrowableBuilder::from(new TestOutcome($event->message()));
 
         $this->ensureCaseBoundary($event->test());
@@ -350,6 +388,10 @@ final class DefaultPrinter
      */
     public function testPhpWarningTriggered(PhpWarningTriggered $event): void
     {
+        if ($this->isIgnoredSuppressedIssue($event)) {
+            return;
+        }
+
         $throwable = ThrowableBuilder::from(new TestOutcome($event->message()));
 
         $this->ensureCaseBoundary($event->test());
@@ -372,6 +414,10 @@ final class DefaultPrinter
      */
     public function testDeprecationTriggered(DeprecationTriggered $event): void
     {
+        if ($this->isIgnoredSuppressedIssue($event)) {
+            return;
+        }
+
         $throwable = ThrowableBuilder::from(new TestOutcome($event->message()));
 
         $this->ensureCaseBoundary($event->test());
@@ -404,6 +450,10 @@ final class DefaultPrinter
      */
     public function testNoticeTriggered(NoticeTriggered $event): void
     {
+        if ($this->isIgnoredSuppressedIssue($event)) {
+            return;
+        }
+
         $throwable = ThrowableBuilder::from(new TestOutcome($event->message()));
 
         $this->ensureCaseBoundary($event->test());
@@ -415,6 +465,10 @@ final class DefaultPrinter
      */
     public function testWarningTriggered(WarningTriggered $event): void
     {
+        if ($this->isIgnoredSuppressedIssue($event)) {
+            return;
+        }
+
         $throwable = ThrowableBuilder::from(new TestOutcome($event->message()));
 
         $this->ensureCaseBoundary($event->test());

--- a/tests/LaravelApp/tests/Unit/SuppressedWarningTest.php
+++ b/tests/LaravelApp/tests/Unit/SuppressedWarningTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+error_reporting(E_ALL);
+
+#[Group('suppressed-warning')]
+class SuppressedWarningTest extends TestCase
+{
+    public function test_suppressed_warning_example()
+    {
+        @file_get_contents(__DIR__.'/missing-fixture-file');
+
+        $this->assertTrue(true);
+    }
+
+    public function test_unsuppressed_warning_example()
+    {
+        file_get_contents(__DIR__.'/missing-fixture-file');
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Unit/Adapters/ArtisanTestCommandTest.php
+++ b/tests/Unit/Adapters/ArtisanTestCommandTest.php
@@ -198,7 +198,7 @@ EOF;
         ]);
 
         expect($output)
-            ->toContain('Tests:    2 deprecated, 2 warnings, 1 risky, 1 incomplete, 2 notices, 1 todo, 1 skipped, 3 passed (9 assertions)')
+            ->toContain('Tests:    1 deprecated, 2 warnings, 1 risky, 1 incomplete, 2 notices, 1 todo, 1 skipped, 4 passed (9 assertions)')
             ->toContain('Top 10 slowest tests:')
             ->toContain('Tests\Feature\ExampleTest > pass example')
             ->toContain('% of ');

--- a/tests/Unit/Adapters/PhpunitTest.php
+++ b/tests/Unit/Adapters/PhpunitTest.php
@@ -72,6 +72,7 @@ class PhpunitTest extends TestCase
             '--exclude-group=environmentTesting',
             '--exclude-group=environmentCustomVariables',
             '--exclude-group=custom-name',
+            '--exclude-group=suppressed-warning',
         ]);
 
         $this->assertConsoleOutputContainsString(<<<EOF
@@ -85,11 +86,27 @@ This is an unexpected output
    PASS  LaravelApp\\tests\Feature\ExampleWithUnexpectedOutputTest
   ✓ pass example
 
-  Tests:    2 deprecated, 2 warnings, 1 risky, 1 incomplete, 2 notices, 1 todo, 1 skipped, 8 passed (15 assertions)
+  Tests:    1 deprecated, 2 warnings, 1 risky, 1 incomplete, 2 notices, 1 todo, 1 skipped, 9 passed (15 assertions)
   Duration:
 EOF,
             $output
         );
+    }
+
+    #[Test]
+    public function it_ignores_issues_that_php_suppressed(): void
+    {
+        $output = $this->runCollisionTests([
+            '--group',
+            'suppressed-warning',
+        ]);
+
+        // PHPUnit discards a suppressed issue unless the matching
+        // ignoreSuppressionOf* source setting is enabled, so the printer must
+        // not report one either.
+        $this->assertConsoleOutputContainsString('✓ suppressed warning example', $output);
+        $this->assertConsoleOutputContainsString('! unsuppressed warning example → file_get_contents(', $output);
+        $this->assertConsoleOutputContainsString('Tests:    1 warning, 1 passed', $output);
     }
 
     #[Test]
@@ -157,10 +174,11 @@ EOF,
             '--exclude-group=fail',
             '--exclude-group=environmentTesting',
             '--exclude-group=environmentCustomVariables',
+            '--exclude-group=suppressed-warning',
         ]);
 
         $this->assertConsoleOutputContainsString(
-            'Tests:    2 deprecated, 2 warnings, 1 risky, 1 incomplete, 2 notices, 1 todo, 1 skipped, 9 passed (16 assertions)',
+            'Tests:    1 deprecated, 2 warnings, 1 risky, 1 incomplete, 2 notices, 1 todo, 1 skipped, 10 passed (16 assertions)',
             $output
         );
 
@@ -179,6 +197,7 @@ EOF,
             '--exclude-group=fail',
             '--exclude-group=environmentTesting',
             '--exclude-group=environmentCustomVariables',
+            '--exclude-group=suppressed-warning',
         ]);
 
         $this->assertConsoleOutputContainsString(


### PR DESCRIPTION
**Fixes #361**, whose analysis of the failure chain is correct and worth reading
first — this PR does not re-derive it.

## The change

`DefaultPrinter` renders PHP diagnostics silenced with `@`. PHPUnit does not:
it discards them unless the matching `ignoreSuppressionOf*` source setting is
enabled, in `PHPUnit\TestRunner\IssueFilter`, and all of those default to
`false`. The printer subscribes to the issue events directly and never checks
`wasSuppressed()`.

Usually that just shows diagnostics the user configured PHPUnit to hide. It can
also kill the run, because the handlers call `ensureCaseBoundary()`, which
flushes synchronously — so an issue raised mid-autoload renders from inside the
`include` still in progress, and the nested Termwind autoload fails. That is
#361.

This adds `isIgnoredSuppressedIssue()`, mirroring `IssueFilter`'s policy, and
guards the six handlers that receive suppressible events. It reads the
configured policy rather than hardcoding "always skip suppressed", so
`ignoreSuppressionOfPhpWarnings="true"` still shows them. `DefaultPrinter`
already imports `PHPUnit\TextUI\Configuration\Registry`, so there is no new
coupling, and `Registry::init()` runs during bootstrap, long before any
test-level event reaches the printer. `wasSuppressed()` is checked first, so
`Registry` is only consulted for events that were actually suppressed.

## Regression range

v8.9.5, via #350 (`e70d9fe257`) — the only functional change to
`DefaultPrinter` between v8.9.4 and v8.9.5. v8.9.4 handled the same events but
recorded them without rendering; #350 added the synchronous flush.

#350 fixed a real ordering bug and this PR keeps it: the flush still happens for
every issue PHPUnit wants reported.

## Test

`tests/LaravelApp/tests/Unit/SuppressedWarningTest.php` raises one suppressed
and one unsuppressed warning; `it_ignores_issues_that_php_suppressed` asserts
the first is hidden and the second still reported. Before this patch it fails
with `Tests: 2 warnings`; after, `1 warning, 1 passed`.

It is under `tests/Unit` rather than `tests/Feature` because Laravel's
`HandleExceptions` installs its own error handler in a booted app, which
swallows suppressed warnings before PHPUnit sees them and turns unsuppressed
ones into exceptions — the scenario cannot occur in a Feature fixture.

Verified against the reproduction in #361 (cold `dg/bypass-finals` cache,
`php artisan test`): **exit 2 → exit 0**, `Tests: 14 passed (18 assertions)`.

## One behaviour change, called out deliberately

Three existing expectations change, all for the same reason, and it deserves an
explicit decision rather than passing as a test edit.

Symfony's `trigger_deprecation()` raises `E_USER_DEPRECATED` through
`@trigger_error()` — suppressed by contract, so only collectors see it.
**PHPUnit already does not report it.** Against this repo's own fixture:

```
$ vendor/bin/phpunit -c tests/LaravelApp/phpunit.xml --group deprecations --display-deprecations
1 test triggered 2 PHP deprecations:
  ... str_contains(): Passing null to parameter #1 ...
  ... str_contains(): Passing null to parameter #2 ...
Tests: 2, Assertions: 2, Deprecations: 2.
```

Two tests ran; only the *unsuppressed* `str_contains()` deprecations are
reported, not the `trigger_deprecation()` one. Collision was reporting it and
now matches PHPUnit, so `user deprecation` moves from `!` to `✓` and the recap
tallies shift by one from `deprecated` to `passed` in `it_has_tests`,
`it_has_recap` and `test_profile`. Anyone wanting the old output sets
`ignoreSuppressionOfDeprecations="true"`, exactly as they would for PHPUnit.

**If you would rather not change deprecation output at all**, the patch narrows
cleanly: drop the `DeprecationTriggered` and `PhpDeprecationTriggered` arms and
their two guards, and the crash fix plus warning/notice filtering stands on its
own with no expectation changes. Happy to do that instead — your call on which
semantics you want.
